### PR TITLE
Add directions to access FM and HyperCore API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Scale Computing Platform REST API Examples
 
-This repository contains several example scripts for running API queries against a HyperCore cluster as well as Scale Computing's Fleet Manager.
+This repository contains several example scripts for running API queries against a HyperCore cluster or Fleet Manager.
 
-These scripts are only examples and demonstrate common use cases with the API.  
-Refer to the API docs on a scale system for a detailed guide on available calls.
+These scripts are only examples and demonstrate common use cases with the APIs.  
 
 Refer to this repository's tags for examples tied to a specific Scale release.
+
+## Full swagger documentation for the APIs
+
+Fleet Manager API: https://api.scalecomputing.com/api/v2
+
+HyperCore API: http://[Your_Clustered_Node_IP}/rest/v1/docs/
+Also linked in the Support tab of the SC//HyperCore Control Panel
+![image](https://github.com/user-attachments/assets/98221da3-9c4f-47a3-b986-cabe14d3d56a)

--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ Refer to this repository's tags for examples tied to a specific Scale release.
 Fleet Manager API: https://api.scalecomputing.com/api/v2
 
 HyperCore API: http://[Your_Clustered_Node_IP}/rest/v1/docs/
+
 Also linked in the Support tab of the Control Panel of any HyperCore system
 ![image](https://github.com/user-attachments/assets/107d6c07-5a70-4749-b6f6-8c4780982ba4)

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ Fleet Manager API: https://api.scalecomputing.com/api/v2
 
 HyperCore API: http://[Your_Clustered_Node_IP}/rest/v1/docs/
 
-Also linked in the Support tab of the Control Panel of any HyperCore system
+A link to the HyperCore API documentation is also available in the Support tab of the Control Panel
 ![image](https://github.com/user-attachments/assets/107d6c07-5a70-4749-b6f6-8c4780982ba4)

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Refer to this repository's tags for examples tied to a specific Scale release.
 Fleet Manager API: https://api.scalecomputing.com/api/v2
 
 HyperCore API: http://[Your_Clustered_Node_IP}/rest/v1/docs/
-Also linked in the Support tab of the SC//HyperCore Control Panel
-![image](https://github.com/user-attachments/assets/98221da3-9c4f-47a3-b986-cabe14d3d56a)
+Also linked in the Support tab of the Control Panel of any HyperCore system
+![image](https://github.com/user-attachments/assets/107d6c07-5a70-4749-b6f6-8c4780982ba4)


### PR DESCRIPTION
Likely users are only coming here after accessing the API docs, but good to be bi-directional and have them here for convenience.