### PR TITLE
Brand compliance: trademark marks and HC3 product name corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains several example scripts for running API queries against
 
 These scripts are only examples and demonstrate common use cases with the APIs.
 
-Refer to this repository's tags for examples tied to a specific Scale release.
+Refer to this repository's tags for examples tied to a specific Scale Computing release.
 
 ## Full swagger documentation for the APIs
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Scale Computing™ Platform REST API Examples
+# Scale Computing™ REST API Examples
 
-This repository contains several example scripts for running API queries against an **SC//HyperCore™** cluster or **SC//Fleet™** platform manager.
+This repository contains several example scripts for running API queries against an **SC//HyperCore™** virtualization suite cluster or **SC//Fleet Manager™** edge orchestration software.
 
 These scripts are only examples and demonstrate common use cases with the APIs.
 
-Refer to this repository's tags for examples tied to a specific Scale Computing release.
+Refer to this repository's tags for examples tied to a specific Scale Computing™ release.
 
 ## Full swagger documentation for the APIs
 
@@ -22,6 +22,6 @@ Scale Computing™ Terraform® Provider for HyperCore — https://github.com/Sca
 
 ---
 
-SC//HyperCore™ and SC//Fleet™ are trademarks of Scale Computing, Inc.
+SC//HyperCore™ and SC//Fleet Manager™ are trademarks of Scale Computing, Inc.
 
 Ansible® is a registered trademark of Red Hat, Inc. Terraform® is a registered trademark of HashiCorp, Inc. All other trademarks are the property of their respective owners.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Scale Computing Platform REST API Examples
+# Scale Computing™ Platform REST API Examples
 
-This repository contains several example scripts for running API queries against a HyperCore cluster or Fleet Manager.
+This repository contains several example scripts for running API queries against an **SC//HyperCore™** cluster or **SC//Fleet™** platform manager.
 
-These scripts are only examples and demonstrate common use cases with the APIs.  
+These scripts are only examples and demonstrate common use cases with the APIs.
 
 Refer to this repository's tags for examples tied to a specific Scale release.
 
@@ -15,7 +15,13 @@ HyperCore API: http://[Your_Clustered_Node_IP}/rest/v1/docs/
 A link to the HyperCore API documentation is also available in the Support tab of the Control Panel
 ![image](https://github.com/user-attachments/assets/107d6c07-5a70-4749-b6f6-8c4780982ba4)
 
-Other automation tools that utilize these apis include:
+Other automation tools that utilize these APIs include:
 
-Scale Computing Ansible Collection for HyperCore - see https://github.com/ScaleComputing/HyperCoreAnsibleCollection
-Scale Computing Terraform Provider for HyperCore - see https://github.com/ScaleComputing/terraform-provider-hypercore
+Scale Computing™ Ansible® Collection for HyperCore — https://github.com/ScaleComputing/HyperCoreAnsibleCollection
+Scale Computing™ Terraform® Provider for HyperCore — https://github.com/ScaleComputing/terraform-provider-hypercore
+
+---
+
+SC//HyperCore™ and SC//Fleet™ are trademarks of Scale Computing, Inc.
+
+Ansible® is a registered trademark of Red Hat, Inc. Terraform® is a registered trademark of HashiCorp, Inc. All other trademarks are the property of their respective owners.

--- a/platform_2025/Platform2025_SnapshotExampleBash.sh
+++ b/platform_2025/Platform2025_SnapshotExampleBash.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCUSERNAME="YOUR_USERNAME"                     # User on a Scale Compuintg cluster with the backup right assigned
+SCUSERNAME="YOUR_USERNAME"                     # User on a Scale Computing HyperCore cluster with the backup right assigned
 SCPASSWD="YOUR_PASSWORD"                       # Password for that user
 SCNODE="IP_OR_FQDN_OF_ONE_NODE"                # IP or FQDN for the cluster
 VMUUID="01234567-89ab-cdef-0123-456789abcdef"  # UUID of the VM we want to make a snapshot of

--- a/platform_2025/README.md
+++ b/platform_2025/README.md
@@ -1,4 +1,4 @@
-# Scale Computing Platform REST API Examples
+# Scale Computing™ Platform REST API Examples
 
 This folder contains the example scripts used during the SC//Platform 'Maximizing Hypercore Rest API' session.
 

--- a/platform_2025/README.md
+++ b/platform_2025/README.md
@@ -1,4 +1,4 @@
-# Scale Computing™ Platform REST API Examples
+# Scale Computing™ REST API Examples
 
 This folder contains the example scripts used during the SC//Platform 'Maximizing Hypercore Rest API' session.
 

--- a/specific_task/README.md
+++ b/specific_task/README.md
@@ -1,9 +1,9 @@
 # Scale Computing System REST API Examples - Task Specific
 
-This repository contains scripts for running task-specific API queries against a Scale system.
+This repository contains scripts for running task-specific API queries against a SC//HyperCore™ cluster.
 
-These scripts are only examples and demonstrate common use cases with the API.  
-Refer to the API docs on a scale system for a detailed guide on available calls.
+These scripts are only examples and demonstrate common use cases with the API.
+Refer to the API docs on a SC//HyperCore™ cluster for a detailed guide on available calls.
 
 
 ### SnapshotReport.ps1

--- a/specific_task/README.md
+++ b/specific_task/README.md
@@ -1,9 +1,9 @@
 # Scale Computing System REST API Examples - Task Specific
 
-This repository contains scripts for running task-specific API queries against a SC//HyperCore™ cluster.
+This repository contains scripts for running task-specific API queries against an SC//HyperCore™ virtualization suite cluster.
 
 These scripts are only examples and demonstrate common use cases with the API.
-Refer to the API docs on a SC//HyperCore™ cluster for a detailed guide on available calls.
+Refer to the API docs on an SC//HyperCore™ virtualization suite cluster for a detailed guide on available calls.
 
 
 ### SnapshotReport.ps1

--- a/specific_task/README.md
+++ b/specific_task/README.md
@@ -1,4 +1,4 @@
-# Scale Computing System REST API Examples - Task Specific
+# SC//HyperCore™ Cluster REST API Examples - Task Specific
 
 This repository contains scripts for running task-specific API queries against an SC//HyperCore™ virtualization suite cluster.
 

--- a/specific_task/SetTag.ps1
+++ b/specific_task/SetTag.ps1
@@ -23,7 +23,7 @@ param(
 	[string]$vmString,
 	[Parameter(mandatory=$true)]
 	[string]$setTag,
-	[PSCredential] $Cred = (Get-Credential -Message "Enter Scale HyperCore Credentials")
+	[PSCredential] $Cred = (Get-Credential -Message "Enter SC//HyperCore Credentials")
 	)
 
 

--- a/specific_task/SetTag.ps1
+++ b/specific_task/SetTag.ps1
@@ -23,7 +23,7 @@ param(
 	[string]$vmString,
 	[Parameter(mandatory=$true)]
 	[string]$setTag,
-	[PSCredential] $Cred = (Get-Credential -Message "Enter Scale HC3 Credentials")
+	[PSCredential] $Cred = (Get-Credential -Message "Enter Scale HyperCore Credentials")
 	)
 
 

--- a/specific_task/SetTag.ps1
+++ b/specific_task/SetTag.ps1
@@ -23,7 +23,7 @@ param(
 	[string]$vmString,
 	[Parameter(mandatory=$true)]
 	[string]$setTag,
-	[PSCredential] $Cred = (Get-Credential -Message "Enter SC//HyperCore Credentials")
+	[PSCredential] $Cred = (Get-Credential -Message "Enter SC//HyperCore virtualization suite credentials")
 	)
 
 

--- a/specific_task/iso-upload.ps1
+++ b/specific_task/iso-upload.ps1
@@ -19,7 +19,7 @@ Param(
     [Parameter(Mandatory = $true,Position = 0)]
     [ValidateNotNullOrEmpty()]
     [string] $Server,
-    [PSCredential] $Credential = (Get-Credential -Message "Enter SC//HyperCore Credentials"),
+    [PSCredential] $Credential = (Get-Credential -Message "Enter SC//HyperCore virtualization suite credentials"),
     [switch] $SkipCertificateCheck
 )
 

--- a/specific_task/iso-upload.ps1
+++ b/specific_task/iso-upload.ps1
@@ -19,7 +19,7 @@ Param(
     [Parameter(Mandatory = $true,Position = 0)]
     [ValidateNotNullOrEmpty()]
     [string] $Server,
-    [PSCredential] $Credential = (Get-Credential -Message "Enter Scale HyperCore Credentials"),
+    [PSCredential] $Credential = (Get-Credential -Message "Enter SC//HyperCore Credentials"),
     [switch] $SkipCertificateCheck
 )
 

--- a/specific_task/iso-upload.ps1
+++ b/specific_task/iso-upload.ps1
@@ -19,7 +19,7 @@ Param(
     [Parameter(Mandatory = $true,Position = 0)]
     [ValidateNotNullOrEmpty()]
     [string] $Server,
-    [PSCredential] $Credential = (Get-Credential -Message "Enter Scale HC3 Credentials"),
+    [PSCredential] $Credential = (Get-Credential -Message "Enter Scale HyperCore Credentials"),
     [switch] $SkipCertificateCheck
 )
 

--- a/vm-lifecycle.ps1
+++ b/vm-lifecycle.ps1
@@ -23,7 +23,7 @@ Param(
     [Parameter(Mandatory = $true,Position = 0)]
     [ValidateNotNullOrEmpty()]
     [string] $Server,
-    [PSCredential] $Credential = (Get-Credential -Message "Enter Scale HyperCore Credentials"),
+    [PSCredential] $Credential = (Get-Credential -Message "Enter SC//HyperCore Credentials"),
     [switch] $SkipCertificateCheck
 )
 

--- a/vm-lifecycle.ps1
+++ b/vm-lifecycle.ps1
@@ -23,7 +23,7 @@ Param(
     [Parameter(Mandatory = $true,Position = 0)]
     [ValidateNotNullOrEmpty()]
     [string] $Server,
-    [PSCredential] $Credential = (Get-Credential -Message "Enter Scale HC3 Credentials"),
+    [PSCredential] $Credential = (Get-Credential -Message "Enter Scale HyperCore Credentials"),
     [switch] $SkipCertificateCheck
 )
 

--- a/vm-lifecycle.ps1
+++ b/vm-lifecycle.ps1
@@ -23,7 +23,7 @@ Param(
     [Parameter(Mandatory = $true,Position = 0)]
     [ValidateNotNullOrEmpty()]
     [string] $Server,
-    [PSCredential] $Credential = (Get-Credential -Message "Enter SC//HyperCore Credentials"),
+    [PSCredential] $Credential = (Get-Credential -Message "Enter SC//HyperCore virtualization suite credentials"),
     [switch] $SkipCertificateCheck
 )
 


### PR DESCRIPTION
## Summary

- **README.md**: Apply brand guidelines — add ™ to Scale Computing™, SC//HyperCore™, SC//Fleet™; add ® to Ansible® and Terraform® on first use; add trademark attribution footer
- **vm-lifecycle.ps1, specific_task/iso-upload.ps1, specific_task/SetTag.ps1**: Update credential prompt text from obsolete "HC3" to "HyperCore"

## What was skipped and why

- `specific_task/superaudit/test_database.py:104` — `'model': 'HC3'` is a test fixture simulating the Node `model` field returned by the HyperCore API. Physical HC3 appliances return "HC3" (or e.g. "HC3-2300") as their hardware model string; changing it would make the test fixture factually incorrect.

## Not in this PR

GitHub repo About/description field change (`REST API Examples for SC//HyperCore™ and SC//Fleet™ platform manager`) — needs to be set via GitHub Settings → About.

🤖 Generated with [Claude Code](https://claude.com/claude-code)