### PR TITLE
Add AI assistant guide, API field notes, and llms.txt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Instructions for AI coding agents
+
+See [CLAUDE.md](CLAUDE.md) — it applies to all AI coding assistants, not just
+Claude. In short: before writing any code against the SC//HyperCore™ REST
+API, read `CLAUDE.md` and `docs/hypercore-api-field-notes.md`.
+The two non-negotiables: poll `GET /rest/v1/TaskTag/<tag>` to a terminal state
+after **every** POST/PATCH/DELETE, and treat every GET response as a
+single-element JSON array (even GET-by-UUID).
+
+---
+
+*Scale Computing, SC//HyperCore, and SC//Fleet Manager are trademarks of
+Scale Computing, Inc. Other marks are the property of their respective owners.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,129 @@
+# SC//HyperCore™ REST API Examples — Guide for AI Coding Assistants
+
+This file is read automatically by Claude Code and other AI coding assistants.
+If you are an AI assistant helping someone write code against the
+SC//HyperCore™ REST API, **read this file and `docs/hypercore-api-field-notes.md`
+before writing any API call.** The SC//HyperCore API has several conventions that
+differ from what you would guess from typical REST APIs, and getting them wrong
+produces confusing failures (400s with misleading messages, silent no-ops, or
+race-condition 500s).
+
+## What this repository is
+
+Customer-facing example scripts for the **SC//HyperCore™** REST API
+(`https://<node-ip>/rest/v1/`) and the **SC//Fleet Manager™** API
+(`https://api.scalecomputing.com/api/v2`). The product name is **SC//HyperCore** —
+you may see "HC3" in older scripts; that is an obsolete name, do not use it in
+new code or docs. Version strings like "HC 9.7" refer to platform versions and
+are fine.
+
+Live OpenAPI spec from any cluster: `https://<node-ip>/rest/v1/openapi.json`
+(Basic Auth required). Swagger UI: `https://<node-ip>/rest/v1/docs/`.
+
+## ⚠ The six rules that prevent 90% of SC//HyperCore API bugs
+
+### 1. Wait for the task after EVERY mutating call — no exceptions
+
+Every POST, PATCH, and DELETE can return `{"taskTag": "<id>", "createdUUID": "..."}`.
+You **must** poll `GET /rest/v1/TaskTag/<tag>` until the task reaches a terminal
+state before issuing the next API call. Skipping this causes intermittent 500
+errors when a second call arrives while the first task is still in flight.
+
+```python
+resp = session.post(url, json=payload)
+tag = resp.json().get("taskTag")
+if tag:
+    while True:
+        task = session.get(f"{base}/rest/v1/TaskTag/{tag}").json()[0]
+        if task["state"] not in ("RUNNING", "QUEUED"):
+            break
+        time.sleep(1)
+    if task["state"] in ("ERROR", "UNINITIALIZED"):
+        raise RuntimeError(task.get("formattedMessage", "task failed"))
+```
+
+`COMPLETE` = success; `ERROR` / `UNINITIALIZED` = failure; anything else
+non-running is treated as success. A bare `requests.post(...)` or
+`session.delete(...)` with no task wait is **always a bug** in SC//HyperCore client
+code — flag it in review.
+
+### 2. Every GET returns a single-element JSON array — even GET-by-UUID
+
+`GET /VirDomain/{uuid}`, `GET /TaskTag/{tag}`, `GET /VirDomainSnapshot/{uuid}` —
+all return `[ {...} ]`, not a bare object. Always unmarshal into a list and take
+the first element. Statically-typed clients (Go, etc.) that decode into a struct
+will fail with "cannot unmarshal array" if they assume a bare object.
+
+### 3. Fetch-then-filter — query filters are rejected on many endpoints
+
+`GET /VirDomainSnapshot?virDomainUUID=...`, `GET /VirDomainSnapshotSchedule?...`,
+`GET /VirDomainBlockDevice?virDomainUUID=...` all return **400**. Fetch the full
+collection and filter client-side. For disks and NICs, prefer the `blockDevs` /
+`netDevs` arrays embedded in the `GET /VirDomain` response.
+
+### 4. Self-signed TLS
+
+SC//HyperCore clusters ship with self-signed certificates. For lab/testing use
+`verify=False` (Python requests) or the equivalent, and say so in a comment. For
+production, retrieve the cluster certificate and pass it as the CA bundle
+instead of disabling verification.
+
+### 5. Check for an in-progress cluster update before writing
+
+While SC//HyperCore software is self-updating, the REST API is effectively read-only and
+mutating calls fail. Before a batch of writes, check
+`GET https://<node-ip>/update/update_status.json` (note: **not** under
+`/rest/v1/`; no auth required) — idle when `updateStage` is `"COMPLETE"` or empty.
+
+### 6. There is no cluster VIP
+
+Every API endpoint is a specific node's IP. If that node goes down, that
+endpoint is dead even though the cluster is fine. Discover all node IPs via
+`GET /rest/v1/Node` (`lanIP` field) and implement client-side failover across
+them for anything long-running.
+
+## Most common naming traps (full table in docs/hypercore-api-field-notes.md)
+
+| If you'd guess... | Actually |
+|---|---|
+| `PATCH /Cluster {"name": ...}` | `{"clusterName": ...}` — `name` is rejected |
+| `SnapshotSchedule` | `VirDomainSnapshotSchedule` |
+| `SyslogTarget` | `AlertSyslogTarget` |
+| `TimeServer` | `TimeSource` |
+| `"protocol": "UDP"` | `"protocol": "SYSLOG_PROTOCOL_UDP"` |
+| SMTP `host`/`username`/`password` | `smtpServer`/`authUser`/`authPassword` |
+| Snapshot body `virDomainUUID` | `domainUUID` |
+| `actionType: "LIVE_MIGRATE"` | `"LIVEMIGRATE"` (no underscore), with `nodeUUID` |
+| `POST /VirDomain/migrate` | `POST /VirDomain/action` (migrate returns 500) |
+| Upload ISOs via `/VirtualDisk/upload` | Three-step `/ISO` flow (`.iso` is rejected) |
+| `labels: {"k": "v"}` | `labels: {"k": {"value": "<base64>"}}` (labels exist on 9.7+ only) |
+
+## Conventions for code in this repository
+
+- **Configuration**: read `SC_HOST`, `SC_USERNAME`, `SC_PASSWORD` environment
+  variables (compatible with the SC//HyperCore Ansible® collection and other
+  Scale Computing tooling),
+  or prompt interactively. Never hardcode cluster IPs or credentials.
+- **Every mutating call** follows Rule 1 above. `vm_lifecycle.py` at the repo
+  root shows the reference `wait_for_task_completion()` pattern.
+- **TLS**: `verify=False` is acceptable in examples but must carry a comment
+  recommending proper certificates for production.
+- New examples get a row in the relevant folder README describing what they do
+  and which API (SC//HyperCore vs SC//Fleet Manager) they target.
+
+## Related tooling (often the better answer)
+
+Before writing raw API code, consider whether an existing maintained tool
+already does the job:
+
+- **Ansible®**: https://github.com/ScaleComputing/HyperCoreAnsibleCollection
+- **Terraform®**: https://github.com/ScaleComputing/terraform-provider-hypercore
+  (also a reference Go client with task-tag handling in `internal/utils/`)
+
+These implement all of the rules above correctly and are good references for
+expected request/response shapes.
+
+---
+
+*Scale Computing, SC//HyperCore, and SC//Fleet Manager are trademarks of
+Scale Computing, Inc. Other marks are the property of their respective owners.*

--- a/docs/hypercore-api-field-notes.md
+++ b/docs/hypercore-api-field-notes.md
@@ -1,0 +1,693 @@
+# SC//HyperCore™ REST API — Field Notes
+
+Practical, empirically-verified notes for anyone writing code against the
+SC//HyperCore™ REST API. Collected from real integration work
+(CLI tooling, Ansible®, Terraform®, Kubernetes® drivers) against SC//HyperCore
+**9.6.x and 9.7.x** clusters. Unless a note carries a version stamp, the
+behavior was observed on both; where versions differ, the difference is
+called out explicitly.
+
+- Base URL: `https://<node-ip>/rest/v1/`
+- Auth: HTTP Basic (a session-cookie login endpoint also exists — see "Auth")
+- TLS: clusters ship with self-signed certificates (see "TLS")
+- Live OpenAPI spec: `https://<node-ip>/rest/v1/openapi.json` (Basic Auth)
+- Swagger UI: `https://<node-ip>/rest/v1/docs/` — also linked from the
+  Support tab of the SC//HyperCore web UI Control Panel
+- API v2 (`/rest/v2/`) exists on SC//HyperCore **9.7.1+ only** (on 9.6 every
+  `/rest/v2/` path returns 404). Live v2 spec:
+  `https://<node-ip>/rest/v2/openAPI.json` (note the capital "A"). These
+  notes target v1 unless stated otherwise.
+
+> These notes describe observed behavior, including a few quirks the official
+> spec does not capture. When the spec and these notes disagree, the notes
+> reflect what the server actually enforces on the versions listed.
+
+## Detecting versions and capabilities
+
+- **Platform version**: `GET /rest/v1/Cluster` → `icosVersion` (e.g.
+  `"9.6.27.225000"`, `"9.7.4.225310"`). This is the value to gate features on.
+- **v2 API presence**: any `/rest/v2/` GET returns 404 on 9.6, normal
+  responses on 9.7.1+.
+- **Do not capability-detect from the v1 spec's version string.** SC//HyperCore
+  9.6.27 and 9.7.4 both serve `/rest/v1/openapi.json` reporting version
+  `1.3.2`, but the content differs (e.g. the `labels` schema exists only in
+  the 9.7 spec). If you need to know whether an endpoint or field exists,
+  check `icosVersion`, or fetch the spec and look for the specific path or
+  schema — never the spec version number.
+
+Features that genuinely require 9.7.1+ (because they're v2-API-only or were
+introduced alongside it): `useUEFISecureBoot` (create-time, v2 only),
+`labels` and `runnable` on VirDomain/VirDomainBlockDevice, `/SNMPConfig`,
+`/VirDomainReplication`, `attemptQuiesce` on snapshot create, and
+`/VirtualDisk/upload` returning a `taskTag` that covers conversion (v2 —
+the v1 upload also returns a `taskTag`, but it does not cover the
+conversion phase; see "Virtual disks"). Notably **not** in that
+list: `snapDiff` (CBT) — it's a v1 endpoint available on 9.6 too (see
+"Changed Block Tracking").
+
+---
+
+## Universal rules — never skip these
+
+### 1. Task-tag waits after every mutating call
+
+Every POST, PATCH, DELETE **can** return a `taskTag` (string) and
+`createdUUID` in the response body. You **must** poll until the task reaches
+a terminal state before issuing the next API call. Skipping this causes
+intermittent 500 errors when a second call hits while the first task is
+in flight.
+
+```python
+resp = session.post(url, json=payload)
+data = resp.json()
+task_tag = data.get("taskTag")
+if task_tag:
+    wait_for_task(task_tag)   # poll GET /rest/v1/TaskTag/<tag> until terminal
+```
+
+The polling endpoint is **`/rest/v1/TaskTag/{tag}`** (not `/Task/{n}`; the
+tag is a string). Terminal states: `COMPLETE` (success), `ERROR` /
+`UNINITIALIZED` (failure). `RUNNING` / `QUEUED` are non-terminal — keep
+polling. Treat any other non-running state as success.
+
+Reference implementations:
+- Python: `vm_lifecycle.py` in this repository (`wait_for_task_completion`)
+- Python (Ansible): `plugins/module_utils/task_tag.py` in the
+  [SC//HyperCore Ansible® collection](https://github.com/ScaleComputing/HyperCoreAnsibleCollection)
+- Go: `internal/utils/` in the
+  [Terraform provider](https://github.com/ScaleComputing/terraform-provider-hypercore)
+
+### 2. Every GET returns a single-element JSON array — even GET-by-UUID
+
+Even when fetching a specific resource (`GET /VirDomain/{uuid}`,
+`GET /VirDomainSnapshot/{uuid}`, `GET /TaskTag/{tag}`), SC//HyperCore software returns a
+**single-element JSON array**, not a bare object. Always unmarshal into a
+list and take the first element.
+
+```python
+records = session.get(f"{base}/rest/v1/VirDomain/{uuid}").json()  # [ {...} ]
+vm = records[0] if records else None
+```
+
+Statically-typed clients (Go and similar) hit a
+`cannot unmarshal array into Go value of type Foo` error if they assume a
+bare object.
+
+### 3. Fetch-then-filter, not query-filter
+
+Several endpoints **reject** query parameters like `?virDomainUUID=...` with
+a 400. Fetch the full list and filter client-side. Known affected endpoints:
+
+- `GET /VirDomainSnapshot?virDomainUUID=...` → 400
+- `GET /VirDomainSnapshotSchedule?virDomainUUID=...` → 400
+- `GET /VirDomainBlockDevice?virDomainUUID=...` → 400
+- `GET /VirDomainNetDevice?virDomainUUID=...` → 400
+
+For disks and NICs, prefer the `blockDevs` / `netDevs` arrays embedded in
+the `GET /VirDomain` response — they're already filtered for you.
+
+### 4. Self-signed TLS
+
+All SC//HyperCore clusters ship with self-signed certificates, so default
+certificate verification fails. For lab and development work, disable
+verification (`verify=False` in Python requests, `-k` in curl) — and note
+in your code that this is a lab convenience. For production automation,
+either install a proper certificate on each node (see "TLS Certificate"
+below) or retrieve the node's certificate once and pass it as the CA
+bundle, which gets you real verification without a CA-signed cert.
+
+### 5. Cluster update awareness
+
+While SC//HyperCore software is self-updating, the REST API is effectively read-only —
+mutating calls fail. Before any batch of writes, check:
+
+```
+GET https://<node-ip>/update/update_status.json
+```
+
+Note this is **not** under `/rest/v1/` and requires no auth. The cluster is
+idle when `updateStage` is `"COMPLETE"` or empty.
+
+### 6. No cluster VIP — plan for node failover
+
+SC//HyperCore clusters do not provide a floating/virtual IP for the REST API.
+Every endpoint is a specific node's address; the same API is served from
+every node, but if the node you configured goes down, that endpoint is dead
+even though the cluster is healthy. For anything long-running:
+
+- Discover all node addresses via `GET /rest/v1/Node` (the `lanIP` field)
+- Implement client-side failover across the node list
+- Don't rely on DNS round-robin alone — most HTTP stacks pick one resolved
+  IP per connection and won't automatically retry siblings
+
+---
+
+## Auth
+
+Two mechanisms:
+
+1. **HTTP Basic** on every request — simplest for scripts and what most
+   examples in this repository use.
+2. **Session cookie** — `POST /rest/v1/login` with
+   `{"username": "...", "password": "...", "useOIDC": false}` returns a
+   `sessionID` (as JSON and as a cookie). Pass it as `Cookie: sessionID=<id>`
+   on subsequent requests, and `POST /rest/v1/logout` when done so sessions
+   don't linger on the cluster.
+
+Quick connectivity test:
+
+```bash
+curl -sk -u <user>:<pass> https://<node-ip>/rest/v1/Cluster | python3 -m json.tool
+```
+
+---
+
+## Endpoint corrections (wrong → right)
+
+| If you'd guess... | Actual |
+|---|---|
+| `SyslogTarget` | `AlertSyslogTarget` |
+| `TimeServer` | `TimeSource` |
+| `GET /Task/{n}` | `GET /TaskTag/{tag}` (tag is a string) |
+| `GET /Version` | `GET /Cluster` → read `icosVersion` from the first element |
+| `cluster.name` field | `cluster.clusterName` (read AND write) |
+| `SnapshotSchedule` | `VirDomainSnapshotSchedule` |
+| `POST /VirDomain/migrate` | `POST /VirDomain/action` with `actionType: "LIVEMIGRATE"` (the migrate endpoint returns 500 on SC//HyperCore 9.7.x) |
+| Upload ISOs via `PUT /VirtualDisk/upload` | Three-step `/ISO` flow — `/VirtualDisk/upload` rejects `.iso` ("File type is invalid") |
+| `labels: {"k": "v"}` | `labels: {"k": {"value": "<base64-string>"}}` — 9.7+ only; see "Labels" |
+| Snapshot body field `virDomainUUID` | `domainUUID` |
+| `description` on `POST /VirDomainBlockDevice` | Rejected ("Property not allowed") |
+| `labels` on `VirDomainSnapshot` | Rejected on POST and PATCH (PATCH returns 405). GET shows `labels: {}` but it is read-only — use the single-string `label` field |
+
+---
+
+## Cluster
+
+`GET /Cluster` — returns a list (usually one item). Fields of note:
+`clusterName` (the cluster name — **not** `name`), `icosVersion` (software
+version string), `uuid`.
+
+```
+PATCH /Cluster/{uuid}   {"clusterName": "new-name"}   # correct
+PATCH /Cluster/{uuid}   {"name": "new-name"}          # WRONG — 400 "Property not allowed"
+```
+
+## Nodes
+
+`GET /Node` — read-only. No POST/PATCH/DELETE. The `disposition` field
+cannot be set via the REST API. `lanIP` is the per-node API address (see
+universal rule 6).
+
+---
+
+## Virtual machines
+
+`GET /VirDomain` — full VM list with embedded `blockDevs` (disks) and
+`netDevs` (NICs). Use those embedded arrays rather than separately querying
+the BlockDevice/NetDevice endpoints with a filter (rejected — rule 3).
+
+### Power actions
+
+`POST /VirDomain/action` with a **list** body:
+
+```json
+[{"virDomainUUID": "<uuid>", "actionType": "START"}]
+```
+
+Valid `actionType`: `START`, `SHUTDOWN`, `STOP`, `PAUSE`, `REBOOT`, `RESET`,
+`LIVEMIGRATE`, `NMI`.
+
+- `SHUTDOWN` sends an ACPI signal; the guest may ignore it. Poll the VM
+  `state` until `SHUTOFF`/`SHUTDOWN`, with a hard-`STOP` fallback on timeout.
+- `STOP` is an immediate hard power-off (the web UI's "Power Off").
+  `FORCE_STOP` is **not** a valid value.
+
+### Live migration
+
+```json
+POST /VirDomain/action
+[{"virDomainUUID": "<uuid>", "actionType": "LIVEMIGRATE", "nodeUUID": "<target-node-uuid>"}]
+```
+
+- `"LIVEMIGRATE"` has no underscore — `"LIVE_MIGRATE"` returns 400.
+- The target field is `nodeUUID`, not `targetNodeUUID`.
+- `POST /VirDomain/migrate` exists in the spec but returns 500 on SC//HyperCore 9.7.x —
+  do not use it.
+
+### Clone
+
+```json
+POST /VirDomain/{uuid}/clone
+{"template": {"name": "clone-name", "description": "..."}}
+```
+
+What a clone carries and what it resets (verified on SC//HyperCore 9.6/9.7):
+
+- **Carried from source** (unless overridden in `template.*`): description,
+  tags, machine type, vCPU/memory, disks (with new disk UUIDs), NICs, SMBIOS.
+- **Always reset, by design** (9.7.x, where these fields exist): `labels` →
+  `{}` and `runnable` → `true` on every clone path (plain clone and
+  clone-from-snapshot). This supports the VM-template workflow
+  (`runnable=false` marks a gold-master; its clones must come out
+  startable). Re-apply labels — and `runnable=false` if the clone is itself
+  a template — with a post-clone PATCH. The same stripping applies to SMB
+  export → import round-trips.
+- **MAC addresses are regenerated by default.** To keep the source's MACs
+  (the web UI's "Clone Existing MAC Addresses" option), GET the source's
+  `netDevs` and pass them — including `macAddress` — in `template.netDevs`.
+  Only do this when the source VM is retired or powered off; duplicate live
+  MACs break the network.
+- **Do not pass `template.smbios`** — on current versions it silently drops
+  both the override and the source's SMBIOS data. Clone without it (the
+  source SMBIOS is inherited), then PATCH the clone if you need changes.
+- `bootDevices` on clones of cloud-image-derived VMs can come out empty —
+  set it explicitly post-clone (see "Cloud-image VM gotchas" below).
+
+### `useUEFISecureBoot` — v2 API only (9.7.1+), and effectively create-only
+
+The field does not exist in the v1 API at all: it appears in neither the v1
+spec nor v1 `GET /VirDomain` responses on any version (verified on 9.6.27
+and 9.7.4). On SC//HyperCore 9.6 there is no way to read or set it via REST.
+
+On 9.7.1+ via the v2 API (`/rest/v2/VirDomain`):
+
+- It is readable on GET and settable **at create time only**, via
+  `options.useUEFISecureBoot` in `VirDomainCreateOptions` on
+  `POST /rest/v2/VirDomain`.
+- PATCHing it, or passing it as a clone `template` override, is a **silent
+  no-op** (HTTP 200, task COMPLETE, stored value unchanged) — verified on
+  9.7.x. The v2 spec does not mark the field read-only; don't trust the
+  spec's writability here.
+- It defaults to `true` — even on BIOS VMs, where it's meaningless but still
+  stored as `true`.
+
+Practical consequence: if a VM needs Secure Boot off (e.g. a migrated
+Windows VM that wasn't Secure Boot enrolled, or a Linux guest with an
+unsigned kernel), set it in the v2 create call — you cannot flip it to
+`false` afterwards through the API.
+
+### Disk create
+
+```json
+POST /VirDomainBlockDevice
+{"virDomainUUID": "<uuid>", "type": "VIRTIO_DISK", "capacity": 10737418240, "cacheMode": "NONE"}
+```
+
+- `type`: `IDE_DISK`, `SCSI_DISK`, `VIRTIO_DISK`, `IDE_CDROM`, `IDE_FLOPPY`,
+  `NVRAM`, `VTPM`
+- `cacheMode`: `NONE`, `WRITEBACK`, `WRITETHROUGH`
+- `description` is rejected on POST ("Property not allowed").
+- Hot-add and hot-remove of block devices against **running** VMs works.
+
+**`tieringPriorityFactor`** (integer, default 8): SSD-tiering priority,
+mapping to the UI "Priority" setting. `0` = bypass SSD tiering entirely —
+useful for temporary/scratch disks (e.g. migration staging) so bulk writes
+don't saturate the SSD tier. On tiered (SSD + HDD) clusters, SC//HyperCore software
+requires all SSD tiers below 90% full to allow snapshots, clones, and VM
+creation — a CRITICAL condition fires when exceeded. On all-flash clusters
+the field is accepted but has no effect, so it's safe to set
+unconditionally. Restore the default (8) on any disk that becomes a
+production VM's disk.
+
+### NIC create
+
+```json
+POST /VirDomainNetDevice
+{"virDomainUUID": "<uuid>", "type": "VIRTIO", "vlan": 0, "connected": true}
+```
+
+`type`: `RTL8139`, `INTEL_E1000`, `VIRTIO`, `PCNET`.
+
+---
+
+## Labels (on `VirDomain` and `VirDomainBlockDevice`) — SC//HyperCore 9.7+ only
+
+Labels do not exist on 9.6: the field is absent from both the 9.6 v1 spec
+and 9.6 `GET /VirDomain` responses (verified on 9.6.27). On 9.7.x the field
+is readable and writable through both `/rest/v1/` and `/rest/v2/` — though
+note that some 9.7 builds' v1 spec omits the labels schema even while the
+server enforces it (another reason not to trust spec contents for
+capability detection).
+
+**`labels` is not a flat string map.** It's a map of objects with a single
+`value` field, and the value must be **base64-encoded**:
+
+```json
+"labels": {
+  "env":   {"value": "cHJvZHVjdGlvbg=="},
+  "owner": {"value": "b3BzLXRlYW0="}
+}
+```
+
+The schema is enforced by the server even where the spec is vague.
+Empirically verified rules (SC//HyperCore 9.7.x):
+
+| Aspect | Rule |
+|---|---|
+| Key charset | Alphanumeric + `-` + `_` only. No `/`, `.`, `:`, spaces, or unicode. |
+| Key length | 1–64 characters. |
+| Value charset | Standard base64 (`A–Z a–z 0–9 + / =`). **Not** base64url — `-` and `_` in values are rejected. |
+| Value length | 0–256 characters (after encoding). |
+| Entry count | Max 64 entries per object. |
+| PATCH semantics | **REPLACE, not MERGE.** PATCH `{"labels": {...}}` overwrites the whole map. To merge: GET → modify client-side → PATCH the full map. |
+| Shape errors | `null` values, bare string values, missing `"value"`, numeric values, and extra fields are all rejected. |
+| Clones | Labels are **not inherited** by clones (any path) — by design. Re-apply via post-clone PATCH. |
+| Export/import | Labels are stripped on SMB export round-trips — by design. Back them up out-of-band if they matter. |
+| Snapshots | `VirDomainSnapshot` rejects labels entirely (see "Snapshots"). |
+
+Tip: if you need to carry an identifier containing `/` or other forbidden
+key characters (e.g. `namespace/name`), put it in the **value** (base64
+accepts anything) and keep the key simple.
+
+---
+
+## Snapshots
+
+### Listing
+
+`GET /VirDomainSnapshot` — rejects `?virDomainUUID=` (rule 3). Fetch all and
+filter client-side on `snap["domainUUID"]` (the field is `domainUUID`,
+**not** `virDomainUUID`).
+
+### Create
+
+```json
+POST /VirDomainSnapshot
+{
+  "domainUUID": "<vm-uuid>",
+  "label": "my-snapshot",
+  "type": "USER",
+  "replication": false
+}
+```
+
+- The field is `domainUUID` — `virDomainUUID` returns 400.
+- `type: "USER"` is the right type for caller-initiated snapshots.
+- SC//HyperCore software defaults `replication` to **true** — override to `false` for
+  transient snapshots (clone/move intermediates), otherwise the snapshot is
+  pushed to any configured replication target, wasting bandwidth and
+  potentially delaying local deletion until the remote acknowledges.
+- `labels` is rejected on POST and PATCH (PATCH on the resource returns 405
+  entirely). Use the single-string `label` field for snapshot identity.
+
+### Response shape gotchas
+
+The `GET /VirDomainSnapshot` response shape is non-obvious:
+
+```json
+{
+  "uuid": "<snap-uuid>",
+  "domainUUID": "<vm-uuid>",
+  "label": "...",
+  "timestamp": 1700000000,
+  "labels": {},
+  "deviceSnapshots": [
+    {"uuid": "<disk-uuid>", "serialNumber": 2, ...}
+  ],
+  "domain": {
+    "uuid": "<vm-uuid>",
+    "blockDevs": [ {"uuid": "...", "type": "VIRTIO_DISK", "capacity": 0, ...} ]
+  },
+  "type": "USER",
+  "replication": false
+}
+```
+
+- **There is no top-level `blockDevices` field.** Per-disk metadata captured
+  at snapshot time (type, capacity, cacheMode...) lives under
+  `domain.blockDevs` — the embedded copy of the VM as it was at snapshot
+  time. A decoder that looks for a top-level disk array will silently get
+  nothing.
+- `deviceSnapshots` is storage-level only — disk UUIDs, serial numbers,
+  checksums. No type/capacity/cacheMode. Don't use it as the source of disk
+  metadata for restores.
+- `labels` appears in the response but is always empty (write-rejected).
+
+### Clone a disk from a snapshot
+
+The accepted body shape for
+`POST /VirDomainBlockDevice/{live-disk-uuid}/clone` **varies between
+builds** — a different shape (`snapshotUUID` + `preserveDiskSignature`) has
+been observed accepted on earlier builds, and on SC//HyperCore 9.7.3 that shape is
+rejected ("Property not allowed"). Verify against your target version. On
+SC//HyperCore 9.7.3 the server enforces this shape:
+
+```json
+{
+  "options":  {"regenerateDiskID": false},
+  "snapUUID": "<vm-snapshot-uuid>",
+  "template": {
+    "virDomainUUID": "<target-vm-uuid>",
+    "type": "VIRTIO_DISK",
+    "capacity": 10737418240,
+    "cacheMode": "NONE"
+  }
+}
+```
+
+- The UUID **in the path** is the (live) disk's UUID (matches
+  `deviceSnapshots[].uuid`); `snapUUID` **in the body** is the VM snapshot's
+  own UUID — not a per-device snapshot UUID.
+- `template.type` and `template.capacity` are required.
+- The clone **auto-attaches** to `template.virDomainUUID` (at
+  `template.slot` if given, else the next free slot).
+- `template.name` is **silently dropped** (same as on VM clone; verified on
+  9.6 and 9.7) — the cloned disk arrives with `name: ""`. Set it via
+  post-clone PATCH if needed; the PATCH works on 9.7+ but is **silently
+  ignored on 9.6**.
+- Snapshot data is independent of the live disk: deleting the live
+  VirDomainBlockDevice does not invalidate the snapshot's `deviceSnapshots`;
+  you can still clone from the snapshot afterwards.
+- `DELETE /VirDomainBlockDevice` also strips that disk's UUID from
+  `VirDomain.bootDevices` — capture the boot order before detaching anything
+  you intend to reattach.
+
+### `regenerateDiskID` should almost always be `false`
+
+On disk attach/clone operations the API default is `true`, which regenerates
+the GPT UUID / MBR signature — and **breaks bootable disk images**: GRUB
+stores the disk UUID in `grub.cfg`, Windows stores the MBR signature in the
+BCD store. Always send `"regenerateDiskID": false` unless you specifically
+need a new disk identity (e.g. attaching a clone alongside its source in the
+same VM).
+
+---
+
+## Snapshot schedules
+
+Endpoint: `VirDomainSnapshotSchedule` (not `SnapshotSchedule`). Rejects
+`?virDomainUUID=` — fetch all, filter client-side.
+
+---
+
+## Cluster settings endpoints
+
+### DNS — `GET/POST/PATCH /DNSConfig`
+Fields: `serverIPs` (list of strings), `searchDomains` (list of strings).
+
+### Time
+- NTP servers: `GET/POST/DELETE /TimeSource`, field `host`. To replace the
+  set: DELETE each existing entry (each returns a task tag — wait!), then
+  POST new ones.
+- Timezone: `GET/POST/PATCH /TimeZone`, field `timeZone` (e.g.
+  `"America/Chicago"`). PATCH returns a task tag — wait before further
+  time-related calls.
+
+### SMTP — `AlertSMTPConfig`
+Field names are non-standard:
+
+| Intuitive | Actual |
+|---|---|
+| `host` | `smtpServer` |
+| `username` | `authUser` |
+| `password` | `authPassword` |
+| `ssl` | `useSSL` |
+| `auth` | `useAuth` |
+| `from` | `fromAddress` |
+
+### Email alert targets — `GET/POST/DELETE /AlertEmailTarget`
+Fields: `emailAddress`, `resendDelay` (seconds), `silentPeriod` (seconds).
+
+### Syslog alert targets — `GET/POST/DELETE /AlertSyslogTarget`
+The `protocol` enum requires the full prefixed value:
+`"SYSLOG_PROTOCOL_UDP"` / `"SYSLOG_PROTOCOL_TCP"`. Bare `"UDP"` returns 400.
+
+### OIDC — `OIDCConfig`
+Fields: `clientID`, `configurationURL`, `scopes`, `sharedSecret`,
+`certificate`. **`sharedSecret` is write-only** — GET always returns `""`,
+but POST/PATCH requires at least one of `sharedSecret` or `certificate` to
+be non-empty. Implication for backup/restore tooling: you cannot round-trip
+the secret through the API; store a placeholder and warn on restore.
+
+### Users & roles
+`GET/POST/PATCH/DELETE /User` — fields: `username`, `password`, `fullName`,
+`roleUUIDs` (list), `sessionLimit`, `sessionExpiration`.
+`GET /Role` — read-only list of available roles.
+
+Consider creating a dedicated, least-privilege API user per integration
+rather than using a shared admin account: you get a clean audit trail in the
+cluster log, and revoking one integration doesn't disturb the others.
+
+### Registration — `GET /Registration` (read-only)
+
+---
+
+## TLS certificate management
+
+`POST /Certificate` with `{"certificate": "<PEM>", "privateKey": "<PEM>"}`
+(field is `privateKey`, camelCase).
+
+- **Per-node, not cluster-wide.** A single POST updates only the node you
+  connected to. To re-certificate a whole cluster, POST to every node's IP
+  individually (`GET /Node` → `lanIP`).
+- **The upload restarts that node's API server** — the HTTPS connection
+  drops mid-call. Wrap the task-tag wait in a retry loop that tolerates
+  connection-reset / SSL-EOF errors for several attempts; the upload usually
+  succeeded.
+- **Validate before uploading** — a mismatched key or expired cert can leave
+  the API unreachable (console-only recovery). Check key↔cert match, expiry,
+  and that the SAN actually covers the names/IPs clients connect with.
+- SAN tips: include every node FQDN **and** every node IP; IPs must be
+  `IP:` SAN entries (a `DNS:10.0.0.1` entry never matches).
+- There is no GET on `/Certificate` and no factory reset. To inspect what a
+  node serves, open a TLS connection and read the presented certificate. To
+  return to a self-signed baseline, generate and upload a fresh self-signed
+  cert (ideally with a correct SAN — better than the generic factory one).
+
+---
+
+## ISO images
+
+ISOs use the `/ISO` endpoint — `/VirtualDisk/upload` **rejects** `.iso`
+files ("File type is invalid").
+
+### Upload (three steps, each task-tag-waited)
+
+```
+1. POST /ISO                {"name": "file.iso", "size": <bytes>, "readyForInsert": false}
+   → {"taskTag": ..., "createdUUID": "<uuid>"}
+2. PUT /ISO/{uuid}/data     Content-Type: application/octet-stream, Content-Length: <bytes>, raw body
+3. PATCH /ISO/{uuid}        {"readyForInsert": true}
+```
+
+`name` must end in `.iso`; `size` is create-only; the read-only `path` field
+is what you mount.
+
+### Mounting / inserting / ejecting
+
+Create a CDROM device using the ISO's `path` (from `GET /ISO/{uuid}`):
+
+```json
+POST /VirDomainBlockDevice
+{"virDomainUUID": "<vm-uuid>", "type": "IDE_CDROM", "capacity": 0, "cacheMode": "NONE", "path": "<iso.path>"}
+```
+
+To swap media on a **running** VM, PATCH the existing CDROM device with
+**both** `path` and `name`: `{"path": "<iso.path>", "name": "<iso-name>"}`
+to insert, `{"path": "", "name": ""}` to eject. Sending only `path` fails
+the task. There is no ISO download endpoint (`GET /ISO/{uuid}/data` → 405).
+
+---
+
+## Virtual disks (non-ISO images)
+
+`.vmdk`, `.qcow2`, `.vhd`/`.vhdx`, `.img` use the VirtualDisk endpoint.
+
+```
+PUT /rest/v1/VirtualDisk/upload?filename=name.ext&filesize=N
+Content-Type: application/octet-stream
+Content-Length: N
+<raw bytes>
+```
+
+- The `filename` extension determines the format and is required.
+- `Content-Length` is **required** — chunked transfer encoding is rejected.
+  When streaming from a URL, get the size from a HEAD request first.
+- Returns `{"taskTag": ..., "createdUUID": ...}` — wait for the task.
+
+**Conversion tracking:** SC//HyperCore software renames the disk during processing:
+`uploading-<name>` → `converting-<name>` → `<name>`. The VirtualDisk record
+has **no `state` field** — poll the `name` field until it equals the final
+name. (ISO uploads have no converting phase. On the v2 API, upload returns
+a taskTag that covers conversion, which is simpler.)
+
+Streaming a disk image from a URL to the cluster without a temp file:
+
+```bash
+URL="https://example.com/disk.img"
+FILESIZE=$(curl -sI "$URL" | awk 'tolower($1) ~ /content-length/ {print $2}' | tr -d '\r')
+curl -L "$URL" | curl -u <user>:<pass> -k \
+  -H "Content-Type: application/octet-stream" \
+  -H "Content-Length: $FILESIZE" \
+  -T - "https://<node-ip>/rest/v1/VirtualDisk/upload?filename=disk.img&filesize=$FILESIZE"
+```
+
+---
+
+## Conditions (health alerts)
+
+`GET /Condition` — the `value` field is a JSON boolean. A useful pattern on
+API errors during heavy operations (imports, clones): fetch `/Condition` and
+surface any SET CRITICAL/ERROR conditions alongside the HTTP error — "SSD
+tier full" explains a 400 far better than "Bad Request".
+
+---
+
+## Cloud-image VM gotchas (Ubuntu cloud images and similar)
+
+VMs provisioned from cloud images (e.g. via clone + cloud-init `cloudInitData`)
+have two independent failure modes that both surface when a **second disk is
+attached and the VM reboots**:
+
+1. **Empty `bootDevices`** → BIOS reports "No bootable device". Always set
+   `bootDevices` explicitly (PATCH the VM with the OS disk's UUID) after
+   cloning/creating.
+2. **Grub uses `root=/dev/vda1`** because Ubuntu cloud images set
+   `GRUB_DISABLE_LINUX_UUID=true` — after a second disk shifts device
+   ordering, the initramfs hangs. Fix inside the guest (re-enable UUID-based
+   root) or keep disk ordering stable.
+
+Practical cloud-init baseline for debuggability on SC//HyperCore: install
+`qemu-guest-agent` (without it, `GET /VirDomain/{uuid}` shows
+`guestAgentState: UNAVAILABLE` and `ipv4Addresses: []`, so you can't find
+the VM's IP via the API).
+
+Cloud-init data is passed at clone/create time as base64:
+
+```json
+"cloudInitData": {"userData": "<base64>", "metaData": "<base64>"}
+```
+
+---
+
+## Changed Block Tracking (snapDiff)
+
+`POST /rest/v1/VirDomainBlockDevice/{disk-uuid}/snapDiff` with
+`{"snapshotSerialFrom": N, "snapshotSerialTo": M}` returns an array of
+changed block intervals (`[{"lower": ..., "upper": ...}, ...]`) between two
+snapshot serials — the native CBT API used by backup integrations.
+
+**Available in the v1 API on both 9.6 and 9.7** (verified live on 9.6.27 and
+9.7.x; present in both versions' v1 specs, and in the v2 spec as well).
+
+- Serial numbers come from `VirDomainSnapshot.deviceSnapshots[].serialNumber`
+  (different from snapshot UUIDs).
+- `snapshotSerialFrom: 0` means HEAD (the live device state).
+- Although it's a POST, the operation is read-only — no taskTag is returned
+  and no task wait is needed.
+
+---
+
+## SC//Fleet Manager™ API
+
+SC//Fleet Manager™ has its own API, separate from that of SC//HyperCore software:
+`https://api.scalecomputing.com/api/v2` with an
+`api-key` header (generate keys at fleet.scalecomputing.com). Standard
+public TLS — no self-signed concerns. Collection endpoints are paginated
+(`offset`/`limit`, max 200 per page) — iterate if you have more clusters
+than one page. See the `Fleet Manager/` folder for examples.
+
+---
+
+*Scale Computing, SC//HyperCore, and SC//Fleet Manager are trademarks of
+Scale Computing, Inc. Other marks are the property of their respective owners.*

--- a/docs/hypercore-api-reference.html
+++ b/docs/hypercore-api-reference.html
@@ -1,0 +1,934 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SC//HyperCore REST API — Field Notes</title>
+
+<style>
+  /* ---------- Tokens ---------- */
+  :root {
+    color-scheme: light dark;
+
+    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, Helvetica, Arial, sans-serif;
+    --font-mono: "SF Mono", ui-monospace, "JetBrains Mono", "Cascadia Code", "Fira Code", Menlo, Consolas, monospace;
+
+    /* Scale Computing brand palette — blue carries the page */
+    --bg: #EDF1F6;
+    --surface: #FFFFFF;
+    --surface-2: #E9EAF0;        /* brand light blue-grey (card bg) */
+    --border: #D6DEE8;
+    --border-strong: #C0CBDA;
+    --text: #113859;             /* brand dark navy — used instead of black */
+    --text-muted: #5C6B7C;
+    --text-faint: #8795A6;
+
+    --accent: #009ADE;           /* brand primary blue — the single bright accent */
+    --accent-strong: #194F90;    /* brand deep blue — readable links / headings */
+    --accent-bg: #E1EFFB;
+
+    --right: #2A8A34;            /* brand green (darkened for text contrast) */
+    --right-bg: #E4F3E6;
+    --wrong: #C23A2E;
+    --wrong-bg: #F7E7E4;
+    --warn: #B4600F;            /* brand orange (darkened for text contrast) */
+    --warn-bg: #FBEBD9;
+
+    --code-bg: #0E2A40;          /* navy console */
+    --code-text: #DCE9F2;
+    --code-border: #1D3E58;
+
+    --shadow: 0 1px 2px rgba(16,36,42,.06), 0 6px 20px rgba(16,36,42,.06);
+    --radius: 10px;
+    --maxw: 1180px;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0A1D30;             /* deep navy, derived from brand #113859 */
+      --surface: #102A42;
+      --surface-2: #16344F;
+      --border: #234460;
+      --border-strong: #315574;
+      --text: #E8EFF5;
+      --text-muted: #9FB2C2;
+      --text-faint: #6F869C;
+
+      --accent: #33B5EE;         /* brighter primary blue for dark ground */
+      --accent-strong: #97CAEB;  /* brand light blue — readable links on navy */
+      --accent-bg: #123048;
+
+      --right: #57C46A;
+      --right-bg: #123020;
+      --wrong: #EB8B7E;
+      --wrong-bg: #3A1E1B;
+      --warn: #F0A85A;
+      --warn-bg: #33260F;
+
+      --code-bg: #071A2B;
+      --code-text: #D6E4F0;
+      --code-border: #17324A;
+
+      --shadow: 0 1px 2px rgba(0,0,0,.4), 0 8px 24px rgba(0,0,0,.35);
+    }
+  }
+
+  /* Explicit toggle overrides both directions */
+  :root[data-theme="light"] {
+    --bg: #EDF1F6; --surface: #FFFFFF; --surface-2: #E9EAF0; --border: #D6DEE8; --border-strong: #C0CBDA;
+    --text: #113859; --text-muted: #5C6B7C; --text-faint: #8795A6;
+    --accent: #009ADE; --accent-strong: #194F90; --accent-bg: #E1EFFB;
+    --right: #2A8A34; --right-bg: #E4F3E6; --wrong: #C23A2E; --wrong-bg: #F7E7E4; --warn: #B4600F; --warn-bg: #FBEBD9;
+    --code-bg: #0E2A40; --code-text: #DCE9F2; --code-border: #1D3E58;
+    --shadow: 0 1px 2px rgba(16,36,42,.06), 0 6px 20px rgba(16,36,42,.06);
+  }
+  :root[data-theme="dark"] {
+    --bg: #0A1D30; --surface: #102A42; --surface-2: #16344F; --border: #234460; --border-strong: #315574;
+    --text: #E8EFF5; --text-muted: #9FB2C2; --text-faint: #6F869C;
+    --accent: #33B5EE; --accent-strong: #97CAEB; --accent-bg: #123048;
+    --right: #57C46A; --right-bg: #123020; --wrong: #EB8B7E; --wrong-bg: #3A1E1B; --warn: #F0A85A; --warn-bg: #33260F;
+    --code-bg: #071A2B; --code-text: #D6E4F0; --code-border: #17324A;
+    --shadow: 0 1px 2px rgba(0,0,0,.4), 0 8px 24px rgba(0,0,0,.35);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 16px;
+    line-height: 1.62;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; text-underline-offset: 2px; }
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
+
+  code, kbd, pre, .mono { font-family: var(--font-mono); font-variant-ligatures: none; }
+
+  /* ---------- Top bar ---------- */
+  header.topbar {
+    position: sticky; top: 0; z-index: 50;
+    background: color-mix(in srgb, var(--bg) 88%, transparent);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border);
+  }
+  .topbar-inner {
+    max-width: var(--maxw); margin: 0 auto; padding: 12px 24px;
+    display: flex; align-items: center; gap: 16px;
+  }
+  .brand { display: flex; align-items: baseline; gap: 10px; min-width: 0; }
+  .brand .slashes { font-family: var(--font-mono); font-weight: 700; color: var(--accent); font-size: 18px; letter-spacing: -1px; }
+  .brand .name { font-weight: 650; font-size: 15px; white-space: nowrap; }
+  .brand .name .dim { color: var(--text-faint); font-weight: 500; }
+  .topbar-spacer { flex: 1; }
+
+  .search {
+    position: relative; display: flex; align-items: center;
+    background: var(--surface); border: 1px solid var(--border-strong);
+    border-radius: 8px; padding: 6px 10px; gap: 8px; width: 260px; max-width: 42vw;
+  }
+  .search:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-bg); }
+  .search svg { flex: none; opacity: .55; }
+  .search input {
+    border: 0; background: transparent; color: var(--text); font-family: var(--font-mono);
+    font-size: 13px; width: 100%; outline: none;
+  }
+  .search input::placeholder { color: var(--text-faint); }
+  .search kbd {
+    font-size: 11px; color: var(--text-faint); border: 1px solid var(--border);
+    border-radius: 4px; padding: 1px 5px; background: var(--bg);
+  }
+
+  .theme-toggle {
+    flex: none; display: inline-flex; align-items: center; justify-content: center;
+    width: 34px; height: 34px; border-radius: 8px; cursor: pointer;
+    background: var(--surface); border: 1px solid var(--border-strong); color: var(--text-muted);
+  }
+  .theme-toggle:hover { color: var(--accent); border-color: var(--accent); }
+  .theme-toggle .sun { display: none; }
+  :root[data-theme="dark"] .theme-toggle .sun { display: block; }
+  :root[data-theme="dark"] .theme-toggle .moon { display: none; }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .theme-toggle .sun { display: block; }
+    :root:not([data-theme="light"]) .theme-toggle .moon { display: none; }
+  }
+
+  /* ---------- Shell ---------- */
+  .shell { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; display: grid; grid-template-columns: 236px minmax(0,1fr); gap: 40px; }
+  nav.toc {
+    position: sticky; top: 66px; align-self: start; height: calc(100vh - 82px);
+    overflow-y: auto; padding: 24px 0 40px; font-size: 13.5px;
+    scrollbar-width: thin;
+  }
+  nav.toc .toc-group { text-transform: uppercase; letter-spacing: .09em; font-size: 11px; font-weight: 700; color: var(--text-faint); margin: 18px 0 8px; }
+  nav.toc a { display: block; color: var(--text-muted); padding: 4px 12px; border-left: 2px solid transparent; margin-left: -2px; line-height: 1.4; }
+  nav.toc a:hover { color: var(--text); text-decoration: none; }
+  nav.toc a.active { color: var(--accent); border-left-color: var(--accent); font-weight: 600; }
+
+  main { padding: 24px 0 96px; min-width: 0; }
+  .reading { max-width: 74ch; }
+
+  /* ---------- Hero ---------- */
+  .hero { padding: 20px 0 8px; }
+  .eyebrow { font-family: var(--font-mono); font-size: 12px; letter-spacing: .04em; color: var(--accent); font-weight: 600; text-transform: uppercase; }
+  h1 { font-size: clamp(28px, 4vw, 40px); line-height: 1.08; letter-spacing: -.02em; margin: 12px 0 14px; text-wrap: balance; }
+  .lede { font-size: 18px; color: var(--text-muted); max-width: 66ch; margin: 0 0 20px; }
+  .meta-strip { display: flex; flex-wrap: wrap; gap: 8px; margin: 4px 0 8px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px;
+    background: var(--surface); border: 1px solid var(--border); border-radius: 999px;
+    padding: 5px 12px; color: var(--text-muted);
+  }
+  .chip b { color: var(--text); font-weight: 600; }
+  .chip .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); }
+  .callout-note {
+    border-left: 3px solid var(--accent); background: var(--accent-bg);
+    padding: 12px 16px; border-radius: 0 8px 8px 0; margin: 22px 0; font-size: 14.5px; color: var(--text);
+  }
+
+  /* ---------- Section headings ---------- */
+  h2.sec { font-size: 13px; text-transform: uppercase; letter-spacing: .1em; color: var(--text-faint);
+           font-weight: 700; margin: 52px 0 4px; padding-top: 8px; }
+  h2.sec::before { content: ""; }
+  .sec-title { font-size: 25px; letter-spacing: -.01em; margin: 4px 0 6px; line-height: 1.15; text-wrap: balance; }
+  .sec-sub { color: var(--text-muted); margin: 0 0 22px; font-size: 15.5px; max-width: 68ch; }
+
+  /* ---------- Rules grid ---------- */
+  .rules { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
+  .rule {
+    position: relative; background: var(--surface); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 18px 18px 18px 18px; box-shadow: var(--shadow);
+    display: flex; flex-direction: column; gap: 8px;
+  }
+  .rule .num {
+    font-family: var(--font-mono); font-weight: 700; font-size: 13px; color: var(--accent);
+    background: var(--accent-bg); border-radius: 6px; width: 30px; height: 26px;
+    display: inline-flex; align-items: center; justify-content: center;
+  }
+  .rule h3 { margin: 0; font-size: 16px; line-height: 1.25; }
+  .rule p { margin: 0; font-size: 13.8px; color: var(--text-muted); line-height: 1.55; }
+  .rule .rule-head { display: flex; align-items: center; gap: 10px; }
+  .rule code { font-size: 12.5px; }
+
+  /* ---------- Trap tables ---------- */
+  .table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); box-shadow: var(--shadow); margin: 4px 0 8px; }
+  table.traps { border-collapse: collapse; width: 100%; font-size: 14px; }
+  table.traps thead th {
+    text-align: left; font-size: 11px; letter-spacing: .08em; text-transform: uppercase;
+    color: var(--text-faint); font-weight: 700; padding: 11px 16px; border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+  }
+  table.traps td { padding: 11px 16px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  table.traps tr:last-child td { border-bottom: 0; }
+  table.traps tr:hover td { background: var(--surface-2); }
+  .cell-wrong { font-family: var(--font-mono); font-size: 12.8px; color: var(--wrong); }
+  .cell-wrong::before { content: "✗ "; font-family: var(--font-sans); font-weight: 700; }
+  .cell-right { font-family: var(--font-mono); font-size: 12.8px; color: var(--right); }
+  .cell-right::before { content: "✓ "; font-family: var(--font-sans); font-weight: 700; }
+  .cell-right em { font-style: normal; color: var(--text-muted); font-family: var(--font-sans); }
+  td.arrow { color: var(--text-faint); width: 1%; text-align: center; padding-left: 4px; padding-right: 4px; }
+
+  /* ---------- Reference (details) ---------- */
+  .ref-controls { display: flex; align-items: center; gap: 14px; margin: 8px 0 14px; flex-wrap: wrap; }
+  .btn-ghost { font-size: 12.5px; color: var(--accent); background: none; border: 1px solid var(--border-strong); border-radius: 7px; padding: 5px 11px; cursor: pointer; font-family: var(--font-sans); }
+  .btn-ghost:hover { border-color: var(--accent); background: var(--accent-bg); }
+  .no-results { display: none; color: var(--text-muted); font-style: italic; padding: 16px 2px; }
+
+  details.ref {
+    background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius);
+    margin: 12px 0; overflow: hidden; box-shadow: var(--shadow);
+  }
+  details.ref > summary {
+    list-style: none; cursor: pointer; padding: 16px 20px; display: flex; align-items: center; gap: 12px;
+    font-weight: 650; font-size: 17px;
+  }
+  details.ref > summary::-webkit-details-marker { display: none; }
+  details.ref > summary .caret { transition: transform .18s ease; color: var(--text-faint); flex: none; }
+  details.ref[open] > summary .caret { transform: rotate(90deg); }
+  details.ref > summary:hover { color: var(--accent); }
+  details.ref > summary .tag {
+    margin-left: auto; font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+    padding: 2px 8px; border-radius: 999px; background: var(--surface-2); color: var(--text-muted); border: 1px solid var(--border);
+    white-space: nowrap;
+  }
+  .ref-body { padding: 4px 22px 22px; border-top: 1px solid var(--border); }
+  .ref-body > *:first-child { margin-top: 16px; }
+
+  h4 { font-size: 15.5px; margin: 26px 0 8px; letter-spacing: -.005em; }
+  h4 .mono { font-size: 14px; color: var(--accent-strong); }
+  p { margin: 12px 0; }
+  .reading p, .ref-body p, .ref-body li { color: var(--text); }
+  .ref-body p, .ref-body li { font-size: 14.8px; }
+  ul, ol { padding-left: 22px; margin: 12px 0; }
+  li { margin: 6px 0; }
+  li::marker { color: var(--text-faint); }
+  hr { border: 0; border-top: 1px solid var(--border); margin: 24px 0; }
+
+  /* inline code chips */
+  :not(pre) > code {
+    font-size: .875em; background: var(--surface-2); border: 1px solid var(--border);
+    border-radius: 5px; padding: .08em .38em; color: var(--text); white-space: nowrap;
+  }
+  .ref-body :not(pre) > code, .reading :not(pre) > code { color: var(--accent-strong); }
+
+  /* code blocks */
+  .codeblock { position: relative; margin: 16px 0; }
+  pre {
+    margin: 0; background: var(--code-bg); color: var(--code-text); border: 1px solid var(--code-border);
+    border-radius: 9px; padding: 15px 16px; overflow-x: auto; font-size: 13px; line-height: 1.55;
+  }
+  pre code { background: none; border: 0; padding: 0; color: inherit; white-space: pre; font-size: inherit; }
+  .lang-label { position: absolute; top: 8px; right: 46px; font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .06em; text-transform: uppercase; color: #7d8f96; }
+  .copy-btn {
+    position: absolute; top: 7px; right: 8px; width: 30px; height: 26px; border-radius: 6px;
+    background: rgba(255,255,255,.06); border: 1px solid rgba(255,255,255,.14); color: #b9c6cc;
+    cursor: pointer; display: inline-flex; align-items: center; justify-content: center;
+  }
+  .copy-btn:hover { background: rgba(255,255,255,.14); color: #fff; }
+  .copy-btn.copied { color: var(--right); border-color: var(--right); }
+
+  /* semantic mini-callouts */
+  .note { border-radius: 8px; padding: 11px 14px; margin: 14px 0; font-size: 14px; border: 1px solid; }
+  .note .lbl { font-weight: 700; font-size: 11px; letter-spacing: .06em; text-transform: uppercase; display: inline-block; margin-right: 6px; }
+  .note.warn { background: var(--warn-bg); border-color: color-mix(in srgb, var(--warn) 35%, transparent); }
+  .note.warn .lbl { color: var(--warn); }
+  .note.wrong { background: var(--wrong-bg); border-color: color-mix(in srgb, var(--wrong) 35%, transparent); }
+  .note.wrong .lbl { color: var(--wrong); }
+  .note.right { background: var(--right-bg); border-color: color-mix(in srgb, var(--right) 35%, transparent); }
+  .note.right .lbl { color: var(--right); }
+
+  .version-pill { font-family: var(--font-mono); font-size: 11px; font-weight: 600; padding: 1px 7px; border-radius: 5px; background: var(--warn-bg); color: var(--warn); border: 1px solid color-mix(in srgb, var(--warn) 30%, transparent); white-space: nowrap; }
+
+  /* small tables inside reference */
+  .ref-body table:not(.traps) { border-collapse: collapse; width: 100%; font-size: 13.6px; margin: 14px 0; }
+  .ref-body table:not(.traps) th { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--border-strong); color: var(--text-faint); font-size: 11px; text-transform: uppercase; letter-spacing: .06em; }
+  .ref-body table:not(.traps) td { padding: 8px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  .ref-body table:not(.traps) td:first-child { font-family: var(--font-mono); font-size: 12.5px; color: var(--wrong); white-space: nowrap; }
+  .ref-body table:not(.traps) td:last-child { font-family: var(--font-mono); font-size: 12.5px; color: var(--right); }
+  .scroll-x { overflow-x: auto; }
+
+  footer { max-width: var(--maxw); margin: 0 auto; padding: 28px 24px 60px; border-top: 1px solid var(--border); color: var(--text-muted); font-size: 13.5px; }
+  footer .reading { max-width: 74ch; }
+
+  /* mobile */
+  .mobile-toc { display: none; }
+  @media (max-width: 900px) {
+    .shell { grid-template-columns: 1fr; }
+    nav.toc { display: none; }
+    .rules { grid-template-columns: 1fr; }
+    .search { width: 180px; }
+    .brand .name { display: none; }
+    .mobile-toc { display: block; margin: 16px 0 4px; }
+  }
+  @media (prefers-reduced-motion: reduce) { * { transition: none !important; scroll-behavior: auto !important; } }
+  html { scroll-behavior: smooth; scroll-padding-top: 78px; }
+</style>
+</head>
+<body>
+
+<header class="topbar">
+  <div class="topbar-inner">
+    <div class="brand">
+      <span class="slashes">//</span>
+      <span class="name">SC//HyperCore REST API <span class="dim">· Field Notes</span></span>
+    </div>
+    <div class="topbar-spacer"></div>
+    <label class="search" aria-label="Filter reference">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+      <input id="filter" type="search" placeholder="Filter reference…" autocomplete="off" spellcheck="false">
+      <kbd>/</kbd>
+    </label>
+    <button class="theme-toggle" id="themeBtn" title="Toggle light / dark" aria-label="Toggle theme">
+      <svg class="moon" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+      <svg class="sun" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
+    </button>
+  </div>
+</header>
+
+<div class="shell">
+  <nav class="toc" id="toc" aria-label="Contents">
+    <div class="toc-group">Start here</div>
+    <a href="#six-rules">The six rules</a>
+    <a href="#traps">Naming traps</a>
+    <div class="toc-group">Reference</div>
+    <a href="#versions">Versions &amp; capabilities</a>
+    <a href="#auth">Auth</a>
+    <a href="#corrections">Endpoint corrections</a>
+    <a href="#cluster">Cluster &amp; nodes</a>
+    <a href="#vms">Virtual machines</a>
+    <a href="#labels">Labels</a>
+    <a href="#snapshots">Snapshots</a>
+    <a href="#settings">Cluster settings</a>
+    <a href="#tls">TLS certificates</a>
+    <a href="#iso">ISO images</a>
+    <a href="#vdisk">Virtual disks</a>
+    <a href="#conditions">Conditions</a>
+    <a href="#cloud">Cloud-image gotchas</a>
+    <a href="#cbt">Changed Block Tracking</a>
+    <a href="#fleet">SC//Fleet Manager</a>
+  </nav>
+
+  <main>
+    <section class="hero reading" id="top">
+      <div class="eyebrow"><b>Scale Computing&trade;</b> · SC//HyperCore&trade; virtualization suite</div>
+      <h1>What the SC//HyperCore REST API actually does — not what the spec says.</h1>
+      <p class="lede">Field-tested notes for writing code against the SC//HyperCore REST API. The conventions here differ from what you'd guess from a typical REST API; getting them wrong produces misleading 400s, silent no-ops, and race-condition 500s.</p>
+      <div class="meta-strip">
+        <span class="chip"><span class="dot"></span> Verified on SC//HyperCore <b>9.6.x</b> &amp; <b>9.7.x</b></span>
+        <span class="chip"><b class="mono">https://&lt;node-ip&gt;/rest/v1/</b></span>
+        <span class="chip">Live spec: <b class="mono">/rest/v1/openapi.json</b></span>
+      </div>
+      <div class="callout-note">
+        These notes describe <b>observed behavior</b>, including quirks the official spec doesn't capture. When the spec and these notes disagree, the notes reflect what the server actually enforces on the versions listed. <b>SC//HyperCore</b> is the product name — older material may say “HC3”, which is obsolete.
+      </div>
+    </section>
+
+    <!-- ============ SIX RULES ============ -->
+    <section id="six-rules">
+      <h2 class="sec">Start here</h2>
+      <h3 class="sec-title">The six rules that prevent 90% of bugs</h3>
+      <p class="sec-sub">Internalize these before writing a single call. Most confusing SC//HyperCore failures trace back to skipping one of them.</p>
+      <div class="rules">
+        <div class="rule">
+          <div class="rule-head"><span class="num">1</span><h3>Wait for the task after every mutating call</h3></div>
+          <p>Every POST / PATCH / DELETE can return a <code>taskTag</code>. Poll <code>GET /TaskTag/&lt;tag&gt;</code> until terminal <em>before</em> the next call. A mutating call with no task-wait is <b>always a bug</b> — skipping it causes intermittent 500s when a second call lands mid-flight.</p>
+        </div>
+        <div class="rule">
+          <div class="rule-head"><span class="num">2</span><h3>Every GET returns a single-element array</h3></div>
+          <p>Even <code>GET /VirDomain/{uuid}</code> and <code>GET /TaskTag/{tag}</code> return <code>[ {…} ]</code>, not a bare object. Unmarshal into a list and take element&nbsp;0. Typed clients that decode into a struct fail with “cannot unmarshal array”.</p>
+        </div>
+        <div class="rule">
+          <div class="rule-head"><span class="num">3</span><h3>Fetch-then-filter</h3></div>
+          <p>Query filters like <code>?virDomainUUID=…</code> are <b>rejected with 400</b> on many endpoints (snapshots, schedules, block/net devices). Fetch the full collection and filter client-side — or read the embedded <code>blockDevs</code>/<code>netDevs</code> arrays.</p>
+        </div>
+        <div class="rule">
+          <div class="rule-head"><span class="num">4</span><h3>Self-signed TLS</h3></div>
+          <p>Clusters ship self-signed certs. For labs, <code>verify=False</code> / <code>-k</code> (with a comment). For production, pin the node certificate as the CA bundle rather than disabling verification.</p>
+        </div>
+        <div class="rule">
+          <div class="rule-head"><span class="num">5</span><h3>Check for an in-progress update first</h3></div>
+          <p>While SC//HyperCore software self-updates, the API is effectively read-only. Before a batch of writes, check <code>GET /update/update_status.json</code> (no auth, <b>not</b> under <code>/rest/v1/</code>) — idle when <code>updateStage</code> is <code>COMPLETE</code> or empty.</p>
+        </div>
+        <div class="rule">
+          <div class="rule-head"><span class="num">6</span><h3>There is no cluster VIP</h3></div>
+          <p>Every endpoint is a specific node's IP. If that node dies, the endpoint is dead even though the cluster is fine. Discover all nodes via <code>GET /Node</code> (<code>lanIP</code>) and fail over client-side.</p>
+        </div>
+      </div>
+
+      <div class="codeblock" style="margin-top:20px">
+        <pre data-lang="python"><code># Rule 1 — the task-tag wait every mutating call needs
+resp = session.post(url, json=payload)
+tag = resp.json().get("taskTag")
+if tag:
+    while True:
+        task = session.get(f"{base}/rest/v1/TaskTag/{tag}").json()[0]
+        if task["state"] not in ("RUNNING", "QUEUED"):
+            break
+        time.sleep(1)
+    if task["state"] in ("ERROR", "UNINITIALIZED"):
+        raise RuntimeError(task.get("formattedMessage", "task failed"))
+# COMPLETE = success; ERROR / UNINITIALIZED = failure; any other non-running = success</code></pre>
+      </div>
+    </section>
+
+    <!-- ============ TRAPS ============ -->
+    <section id="traps">
+      <h2 class="sec">Start here</h2>
+      <h3 class="sec-title">Naming traps</h3>
+      <p class="sec-sub">The intuitive name is wrong often enough to be worth a lookup table. Left is what you'd reach for; right is what the server accepts.</p>
+      <div class="table-wrap">
+        <table class="traps">
+          <thead><tr><th>You'd guess…</th><th></th><th>Actually</th></tr></thead>
+          <tbody>
+            <tr><td class="cell-wrong">PATCH /Cluster {"name": …}</td><td class="arrow">→</td><td class="cell-right">{"clusterName": …} <em>— “name” is rejected</em></td></tr>
+            <tr><td class="cell-wrong">SnapshotSchedule</td><td class="arrow">→</td><td class="cell-right">VirDomainSnapshotSchedule</td></tr>
+            <tr><td class="cell-wrong">SyslogTarget</td><td class="arrow">→</td><td class="cell-right">AlertSyslogTarget</td></tr>
+            <tr><td class="cell-wrong">TimeServer</td><td class="arrow">→</td><td class="cell-right">TimeSource</td></tr>
+            <tr><td class="cell-wrong">GET /Task/{n}</td><td class="arrow">→</td><td class="cell-right">GET /TaskTag/{tag} <em>— tag is a string</em></td></tr>
+            <tr><td class="cell-wrong">GET /Version</td><td class="arrow">→</td><td class="cell-right">GET /Cluster → icosVersion</td></tr>
+            <tr><td class="cell-wrong">"protocol": "UDP"</td><td class="arrow">→</td><td class="cell-right">"SYSLOG_PROTOCOL_UDP"</td></tr>
+            <tr><td class="cell-wrong">SMTP host / username / password</td><td class="arrow">→</td><td class="cell-right">smtpServer / authUser / authPassword</td></tr>
+            <tr><td class="cell-wrong">Snapshot body virDomainUUID</td><td class="arrow">→</td><td class="cell-right">domainUUID</td></tr>
+            <tr><td class="cell-wrong">actionType: "LIVE_MIGRATE"</td><td class="arrow">→</td><td class="cell-right">"LIVEMIGRATE" <em>— no underscore, with nodeUUID</em></td></tr>
+            <tr><td class="cell-wrong">POST /VirDomain/migrate</td><td class="arrow">→</td><td class="cell-right">POST /VirDomain/action <em>— migrate returns 500</em></td></tr>
+            <tr><td class="cell-wrong">Upload ISOs via /VirtualDisk/upload</td><td class="arrow">→</td><td class="cell-right">Three-step /ISO flow <em>— .iso is rejected</em></td></tr>
+            <tr><td class="cell-wrong">labels: {"k": "v"}</td><td class="arrow">→</td><td class="cell-right">labels: {"k": {"value": "&lt;base64&gt;"}} <em>— 9.7+ only</em></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- ============ FULL REFERENCE ============ -->
+    <section id="reference">
+      <h2 class="sec">Complete reference</h2>
+      <h3 class="sec-title">Field notes, per endpoint</h3>
+      <p class="sec-sub">The full empirically-verified reference. Use the filter box up top to jump to a field or endpoint; every section is collapsible.</p>
+      <div class="ref-controls">
+        <button class="btn-ghost" id="expandAll">Expand all</button>
+        <button class="btn-ghost" id="collapseAll">Collapse all</button>
+      </div>
+      <div class="no-results" id="noResults">No sections match that filter.</div>
+
+      <!-- Versions -->
+      <details class="ref" id="versions" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>Detecting versions &amp; capabilities<span class="tag">GET /Cluster</span></summary>
+        <div class="ref-body">
+          <ul>
+            <li><b>Platform version:</b> <code>GET /Cluster</code> → <code>icosVersion</code> (e.g. <code>9.6.27.225000</code>, <code>9.7.4.225310</code>). This is the value to gate features on.</li>
+            <li><b>v2 API presence:</b> any <code>/rest/v2/</code> GET returns 404 on 9.6, normal responses on 9.7.1+. Live v2 spec: <code>/rest/v2/openAPI.json</code> (capital “A”).</li>
+          </ul>
+          <div class="note wrong"><span class="lbl">Don't</span> capability-detect from the v1 spec's version string. 9.6.27 and 9.7.4 both report spec version <code>1.3.2</code> while their <em>contents</em> differ (the <code>labels</code> schema exists only in the 9.7 spec). Check <code>icosVersion</code>, or fetch the spec and look for the specific path/schema — never the spec version number.</div>
+          <p>Features that genuinely require <span class="version-pill">9.7.1+</span> (v2-only or introduced alongside it): <code>useUEFISecureBoot</code> (create-time, v2), <code>labels</code> &amp; <code>runnable</code> on VirDomain/VirDomainBlockDevice, <code>/SNMPConfig</code>, <code>/VirDomainReplication</code>, <code>attemptQuiesce</code> on snapshot create, and <code>/VirtualDisk/upload</code> returning a <code>taskTag</code> that covers conversion (the v1 upload also returns a <code>taskTag</code>, but it doesn't cover the conversion phase). <b>Not</b> in that list: <code>snapDiff</code> (CBT) — a v1 endpoint available on 9.6 too.</p>
+        </div>
+      </details>
+
+      <!-- Auth -->
+      <details class="ref" id="auth" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>Auth<span class="tag">Basic · session</span></summary>
+        <div class="ref-body">
+          <ol>
+            <li><b>HTTP Basic</b> on every request — simplest for scripts, and what most examples use.</li>
+            <li><b>Session cookie</b> — <code>POST /login</code> with <code>{"username":…,"password":…,"useOIDC":false}</code> returns a <code>sessionID</code> (JSON + cookie). Pass <code>Cookie: sessionID=&lt;id&gt;</code> afterward, and <code>POST /logout</code> when done so sessions don't linger.</li>
+          </ol>
+          <div class="codeblock">
+            <pre data-lang="bash"><code>curl -sk -u &lt;user&gt;:&lt;pass&gt; https://&lt;node-ip&gt;/rest/v1/Cluster | python3 -m json.tool</code></pre>
+          </div>
+          <div class="note right"><span class="lbl">Tip</span> Create a dedicated, least-privilege API user per integration rather than sharing an admin account — you get a clean audit trail, and revoking one integration doesn't disturb the others.</div>
+        </div>
+      </details>
+
+      <!-- Corrections -->
+      <details class="ref" id="corrections" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>Endpoint corrections<span class="tag">wrong → right</span></summary>
+        <div class="ref-body">
+          <div class="scroll-x"><table>
+            <thead><tr><th>If you'd guess…</th><th>Actual</th></tr></thead>
+            <tbody>
+              <tr><td>SyslogTarget</td><td>AlertSyslogTarget</td></tr>
+              <tr><td>TimeServer</td><td>TimeSource</td></tr>
+              <tr><td>GET /Task/{n}</td><td>GET /TaskTag/{tag} (string tag)</td></tr>
+              <tr><td>GET /Version</td><td>GET /Cluster → icosVersion (element 0)</td></tr>
+              <tr><td>cluster.name</td><td>cluster.clusterName (read AND write)</td></tr>
+              <tr><td>SnapshotSchedule</td><td>VirDomainSnapshotSchedule</td></tr>
+              <tr><td>POST /VirDomain/migrate</td><td>POST /VirDomain/action · LIVEMIGRATE (migrate = 500)</td></tr>
+              <tr><td>PUT /VirtualDisk/upload for .iso</td><td>Three-step /ISO flow (.iso rejected)</td></tr>
+              <tr><td>labels: {"k":"v"}</td><td>labels: {"k":{"value":"&lt;b64&gt;"}} — 9.7+</td></tr>
+              <tr><td>Snapshot body virDomainUUID</td><td>domainUUID</td></tr>
+              <tr><td>description on POST /VirDomainBlockDevice</td><td>Rejected — “Property not allowed”</td></tr>
+              <tr><td>labels on VirDomainSnapshot</td><td>Rejected (PATCH = 405); use single-string label</td></tr>
+            </tbody>
+          </table></div>
+        </div>
+      </details>
+
+      <!-- Cluster & nodes -->
+      <details class="ref" id="cluster" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>Cluster &amp; nodes<span class="tag">/Cluster · /Node</span></summary>
+        <div class="ref-body">
+          <p><code>GET /Cluster</code> returns a list (usually one). Fields of note: <code>clusterName</code> (<b>not</b> <code>name</code>), <code>icosVersion</code>, <code>uuid</code>.</p>
+          <div class="codeblock">
+            <pre data-lang="http"><code>PATCH /Cluster/{uuid}   {"clusterName": "new-name"}   ✓ correct
+PATCH /Cluster/{uuid}   {"name": "new-name"}          ✗ 400 "Property not allowed"</code></pre>
+          </div>
+          <p><code>GET /Node</code> is read-only (no POST/PATCH/DELETE). <code>disposition</code> cannot be set via REST. <code>lanIP</code> is the per-node API address — the basis for the failover in rule&nbsp;6.</p>
+        </div>
+      </details>
+
+      <!-- VMs -->
+      <details class="ref" id="vms" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>Virtual machines<span class="tag">/VirDomain</span></summary>
+        <div class="ref-body">
+          <p><code>GET /VirDomain</code> returns the full VM list with embedded <code>blockDevs</code> (disks) and <code>netDevs</code> (NICs). Use those embedded arrays rather than querying the BlockDevice/NetDevice endpoints with a filter (rejected — rule&nbsp;3).</p>
+
+          <h4>Power actions — <span class="mono">POST /VirDomain/action</span></h4>
+          <p>Body is a <b>list</b>:</p>
+          <div class="codeblock"><pre data-lang="json"><code>[{"virDomainUUID": "&lt;uuid&gt;", "actionType": "START"}]</code></pre></div>
+          <p>Valid <code>actionType</code>: <code>START</code>, <code>SHUTDOWN</code>, <code>STOP</code>, <code>PAUSE</code>, <code>REBOOT</code>, <code>RESET</code>, <code>LIVEMIGRATE</code>, <code>NMI</code>.</p>
+          <ul>
+            <li><code>SHUTDOWN</code> sends an ACPI signal the guest may ignore. Poll <code>state</code> until <code>SHUTOFF</code>/<code>SHUTDOWN</code>, with a hard-<code>STOP</code> fallback on timeout.</li>
+            <li><code>STOP</code> is an immediate hard power-off (UI “Power Off”). <code>FORCE_STOP</code> is <b>not</b> valid.</li>
+          </ul>
+
+          <h4>Live migration</h4>
+          <div class="codeblock"><pre data-lang="json"><code>POST /VirDomain/action
+[{"virDomainUUID": "&lt;uuid&gt;", "actionType": "LIVEMIGRATE", "nodeUUID": "&lt;target-node-uuid&gt;"}]</code></pre></div>
+          <ul>
+            <li><code>"LIVEMIGRATE"</code> has no underscore — <code>"LIVE_MIGRATE"</code> returns 400.</li>
+            <li>Target field is <code>nodeUUID</code>, not <code>targetNodeUUID</code>.</li>
+            <li><code>POST /VirDomain/migrate</code> exists in the spec but <b>returns 500</b> on 9.7.x — don't use it.</li>
+          </ul>
+
+          <h4>Clone — <span class="mono">POST /VirDomain/{uuid}/clone</span></h4>
+          <div class="codeblock"><pre data-lang="json"><code>{"template": {"name": "clone-name", "description": "..."}}</code></pre></div>
+          <ul>
+            <li><b>Carried from source</b> (unless overridden in <code>template.*</code>): description, tags, machine type, vCPU/memory, disks (new disk UUIDs), NICs, SMBIOS.</li>
+            <li><b>Always reset by design</b> (9.7.x): <code>labels → {}</code> and <code>runnable → true</code> on every clone path. Supports the gold-master template workflow. Re-apply with a post-clone PATCH.</li>
+            <li><b>MAC addresses are regenerated by default.</b> To keep them (UI “Clone Existing MAC Addresses”), pass the source's <code>netDevs</code> — including <code>macAddress</code> — in <code>template.netDevs</code>. Only when the source is retired/off; duplicate live MACs break the network.</li>
+            <li><b>Do not pass <code>template.smbios</code></b> — it silently drops both the override and the source's SMBIOS. Clone without it, then PATCH.</li>
+            <li><code>bootDevices</code> on clones of cloud-image VMs can come out empty — set it explicitly post-clone.</li>
+          </ul>
+
+          <h4><span class="mono">useUEFISecureBoot</span> <span class="version-pill">v2 · 9.7.1+</span> — create-only</h4>
+          <p>The field doesn't exist in v1 at all (absent from the v1 spec and v1 <code>GET /VirDomain</code> on every version). On 9.6 there is no way to read or set it via REST. On 9.7.1+ via <code>/rest/v2/VirDomain</code>:</p>
+          <ul>
+            <li>Readable on GET, settable <b>at create time only</b> via <code>options.useUEFISecureBoot</code>.</li>
+            <li>PATCHing it, or passing it as a clone override, is a <b>silent no-op</b> (200, task COMPLETE, value unchanged). The v2 spec doesn't mark it read-only — don't trust that.</li>
+            <li>Defaults to <code>true</code>, even on BIOS VMs where it's meaningless.</li>
+          </ul>
+          <div class="note warn"><span class="lbl">Consequence</span> If a VM needs Secure Boot off (a migrated Windows VM not enrolled, or a Linux guest with an unsigned kernel), set it in the v2 <em>create</em> call — you cannot flip it to <code>false</code> afterward through the API.</div>
+
+          <h4>Disk create — <span class="mono">POST /VirDomainBlockDevice</span></h4>
+          <div class="codeblock"><pre data-lang="json"><code>{"virDomainUUID": "&lt;uuid&gt;", "type": "VIRTIO_DISK", "capacity": 10737418240, "cacheMode": "NONE"}</code></pre></div>
+          <ul>
+            <li><code>type</code>: <code>IDE_DISK</code>, <code>SCSI_DISK</code>, <code>VIRTIO_DISK</code>, <code>IDE_CDROM</code>, <code>IDE_FLOPPY</code>, <code>NVRAM</code>, <code>VTPM</code>.</li>
+            <li><code>cacheMode</code>: <code>NONE</code>, <code>WRITEBACK</code>, <code>WRITETHROUGH</code>.</li>
+            <li><code>description</code> is rejected on POST. Hot-add / hot-remove against <b>running</b> VMs works.</li>
+            <li><b><code>tieringPriorityFactor</code></b> (int, default 8): SSD-tiering priority. <code>0</code> bypasses SSD tiering — useful for scratch/migration-staging disks. On tiered clusters, all SSD tiers must be below 90% full for snapshots/clones/creation (a CRITICAL condition fires otherwise). No effect on all-flash — safe to set unconditionally. Restore the default (8) on any disk that becomes a production disk.</li>
+          </ul>
+
+          <h4>NIC create — <span class="mono">POST /VirDomainNetDevice</span></h4>
+          <div class="codeblock"><pre data-lang="json"><code>{"virDomainUUID": "&lt;uuid&gt;", "type": "VIRTIO", "vlan": 0, "connected": true}</code></pre></div>
+          <p><code>type</code>: <code>RTL8139</code>, <code>INTEL_E1000</code>, <code>VIRTIO</code>, <code>PCNET</code>.</p>
+        </div>
+      </details>
+
+      <!-- Labels -->
+      <details class="ref" id="labels" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>Labels<span class="tag">9.7+ · base64</span></summary>
+        <div class="ref-body">
+          <p>On <code>VirDomain</code> and <code>VirDomainBlockDevice</code>, <span class="version-pill">9.7+ only</span>. Absent from the 9.6 spec and responses. On 9.7.x it works through both v1 and v2 — though some 9.7 builds' v1 spec omits the schema even while the server enforces it.</p>
+          <div class="note wrong"><span class="lbl">Not a flat map</span> <code>labels</code> is a map of objects with a single <code>value</code> field, and the value must be <b>base64-encoded</b>.</div>
+          <div class="codeblock"><pre data-lang="json"><code>"labels": {
+  "env":   {"value": "cHJvZHVjdGlvbg=="},
+  "owner": {"value": "b3BzLXRlYW0="}
+}</code></pre></div>
+          <div class="scroll-x"><table class="traps" style="box-shadow:none;border:1px solid var(--border)">
+            <thead><tr><th>Aspect</th><th>Rule</th></tr></thead>
+            <tbody>
+              <tr><td style="font-family:var(--font-sans)">Key charset</td><td style="font-family:var(--font-sans)">Alphanumeric + <code>-</code> + <code>_</code> only. No <code>/</code>, <code>.</code>, <code>:</code>, spaces, or unicode.</td></tr>
+              <tr><td style="font-family:var(--font-sans)">Key length</td><td style="font-family:var(--font-sans)">1–64 characters.</td></tr>
+              <tr><td style="font-family:var(--font-sans)">Value charset</td><td style="font-family:var(--font-sans)">Standard base64 (<code>A–Z a–z 0–9 + / =</code>). <b>Not</b> base64url — <code>-</code>/<code>_</code> rejected.</td></tr>
+              <tr><td style="font-family:var(--font-sans)">Value length</td><td style="font-family:var(--font-sans)">0–256 chars (after encoding).</td></tr>
+              <tr><td style="font-family:var(--font-sans)">Entry count</td><td style="font-family:var(--font-sans)">Max 64 entries.</td></tr>
+              <tr><td style="font-family:var(--font-sans)">PATCH semantics</td><td style="font-family:var(--font-sans)"><b>REPLACE, not MERGE</b> — overwrites the whole map. To merge: GET → modify → PATCH the full map.</td></tr>
+              <tr><td style="font-family:var(--font-sans)">Shape errors</td><td style="font-family:var(--font-sans)"><code>null</code>, bare strings, missing <code>"value"</code>, numbers, extra fields — all rejected.</td></tr>
+              <tr><td style="font-family:var(--font-sans)">Clones</td><td style="font-family:var(--font-sans)">Not inherited by clones (any path). Re-apply post-clone.</td></tr>
+              <tr><td style="font-family:var(--font-sans)">Export/import</td><td style="font-family:var(--font-sans)">Stripped on SMB export round-trips. Back up out-of-band.</td></tr>
+              <tr><td style="font-family:var(--font-sans)">Snapshots</td><td style="font-family:var(--font-sans)"><code>VirDomainSnapshot</code> rejects labels entirely.</td></tr>
+            </tbody>
+          </table></div>
+          <div class="note right"><span class="lbl">Tip</span> To carry an identifier with forbidden key characters (e.g. <code>namespace/name</code>), put it in the <b>value</b> (base64 accepts anything) and keep the key simple.</div>
+        </div>
+      </details>
+
+      <!-- Snapshots -->
+      <details class="ref" id="snapshots" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>Snapshots &amp; schedules<span class="tag">/VirDomainSnapshot</span></summary>
+        <div class="ref-body">
+          <h4>Listing</h4>
+          <p><code>GET /VirDomainSnapshot</code> rejects <code>?virDomainUUID=</code> (rule 3). Fetch all and filter on <code>snap["domainUUID"]</code> — the field is <code>domainUUID</code>, <b>not</b> <code>virDomainUUID</code>.</p>
+
+          <h4>Create</h4>
+          <div class="codeblock"><pre data-lang="json"><code>POST /VirDomainSnapshot
+{"domainUUID": "&lt;vm-uuid&gt;", "label": "my-snapshot", "type": "USER", "replication": false}</code></pre></div>
+          <ul>
+            <li>Field is <code>domainUUID</code> — <code>virDomainUUID</code> returns 400.</li>
+            <li><code>type: "USER"</code> for caller-initiated snapshots.</li>
+            <li>SC//HyperCore software defaults <code>replication</code> to <b>true</b> — override to <code>false</code> for transient snapshots, else it's pushed to any replication target (wasted bandwidth, delayed local deletion).</li>
+            <li><code>labels</code> rejected on POST and PATCH (PATCH = 405). Use the single-string <code>label</code> field.</li>
+          </ul>
+
+          <h4>Response shape gotchas</h4>
+          <div class="note wrong"><span class="lbl">No top-level blockDevices</span> Per-disk metadata captured at snapshot time (type, capacity, cacheMode) lives under <code>domain.blockDevs</code> — the embedded copy of the VM as it was. A decoder looking for a top-level disk array silently gets nothing.</div>
+          <ul>
+            <li><code>deviceSnapshots</code> is storage-level only — disk UUIDs, serial numbers, checksums. No type/capacity/cacheMode; don't use it as disk metadata for restores.</li>
+            <li><code>labels</code> appears but is always empty (write-rejected).</li>
+          </ul>
+
+          <h4>Clone a disk from a snapshot <span class="version-pill">shape varies by build</span></h4>
+          <p>The accepted body for <code>POST /VirDomainBlockDevice/{live-disk-uuid}/clone</code> <b>varies between builds</b>. On 9.7.3 the server enforces:</p>
+          <div class="codeblock"><pre data-lang="json"><code>{
+  "options":  {"regenerateDiskID": false},
+  "snapUUID": "&lt;vm-snapshot-uuid&gt;",
+  "template": {
+    "virDomainUUID": "&lt;target-vm-uuid&gt;",
+    "type": "VIRTIO_DISK",
+    "capacity": 10737418240,
+    "cacheMode": "NONE"
+  }
+}</code></pre></div>
+          <ul>
+            <li>UUID <b>in the path</b> = the live disk's UUID (matches <code>deviceSnapshots[].uuid</code>); <code>snapUUID</code> <b>in the body</b> = the VM snapshot's own UUID (not a per-device UUID).</li>
+            <li><code>template.type</code> and <code>template.capacity</code> are required. The clone auto-attaches to <code>template.virDomainUUID</code>.</li>
+            <li><code>template.name</code> is silently dropped (arrives as <code>name: ""</code>). PATCH post-clone — works on 9.7+, silently ignored on 9.6.</li>
+            <li>Snapshot data is independent of the live disk: deleting the live device doesn't invalidate the snapshot.</li>
+            <li><code>DELETE /VirDomainBlockDevice</code> also strips that disk's UUID from <code>VirDomain.bootDevices</code> — capture boot order before detaching anything you'll reattach.</li>
+          </ul>
+          <div class="note wrong"><span class="lbl">regenerateDiskID</span> Defaults to <code>true</code> on attach/clone, which regenerates the GPT UUID / MBR signature and <b>breaks bootable images</b> (GRUB stores the disk UUID; Windows stores the MBR signature in BCD). Always send <code>"regenerateDiskID": false</code> unless you specifically need a new disk identity.</div>
+
+          <h4>Snapshot schedules</h4>
+          <p>Endpoint is <code>VirDomainSnapshotSchedule</code> (not <code>SnapshotSchedule</code>). Rejects <code>?virDomainUUID=</code> — fetch all, filter client-side.</p>
+        </div>
+      </details>
+
+      <!-- Settings -->
+      <details class="ref" id="settings" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>Cluster settings<span class="tag">DNS · time · SMTP · users</span></summary>
+        <div class="ref-body">
+          <h4>DNS — <span class="mono">/DNSConfig</span></h4>
+          <p>Fields: <code>serverIPs</code> (list), <code>searchDomains</code> (list).</p>
+
+          <h4>Time</h4>
+          <ul>
+            <li>NTP servers: <code>GET/POST/DELETE /TimeSource</code>, field <code>host</code>. To replace the set: DELETE each existing entry (each returns a task tag — wait!), then POST new ones.</li>
+            <li>Timezone: <code>GET/POST/PATCH /TimeZone</code>, field <code>timeZone</code> (e.g. <code>America/Chicago</code>). PATCH returns a task tag — wait before further time calls.</li>
+          </ul>
+
+          <h4>SMTP — <span class="mono">/AlertSMTPConfig</span> (non-standard field names)</h4>
+          <div class="scroll-x"><table>
+            <thead><tr><th>Intuitive</th><th>Actual</th></tr></thead>
+            <tbody>
+              <tr><td>host</td><td>smtpServer</td></tr>
+              <tr><td>username</td><td>authUser</td></tr>
+              <tr><td>password</td><td>authPassword</td></tr>
+              <tr><td>ssl</td><td>useSSL</td></tr>
+              <tr><td>auth</td><td>useAuth</td></tr>
+              <tr><td>from</td><td>fromAddress</td></tr>
+            </tbody>
+          </table></div>
+
+          <h4>Alert targets</h4>
+          <ul>
+            <li><b>Email</b> — <code>/AlertEmailTarget</code>: <code>emailAddress</code>, <code>resendDelay</code> (s), <code>silentPeriod</code> (s).</li>
+            <li><b>Syslog</b> — <code>/AlertSyslogTarget</code>: <code>protocol</code> needs the full prefix <code>"SYSLOG_PROTOCOL_UDP"</code> / <code>"SYSLOG_PROTOCOL_TCP"</code>. Bare <code>"UDP"</code> = 400.</li>
+          </ul>
+
+          <h4>OIDC — <span class="mono">/OIDCConfig</span></h4>
+          <p>Fields: <code>clientID</code>, <code>configurationURL</code>, <code>scopes</code>, <code>sharedSecret</code>, <code>certificate</code>.</p>
+          <div class="note warn"><span class="lbl">Write-only</span> <code>sharedSecret</code> — GET always returns <code>""</code>, but POST/PATCH requires at least one of <code>sharedSecret</code> or <code>certificate</code> non-empty. You can't round-trip the secret through the API; store a placeholder and warn on restore.</div>
+
+          <h4>Users &amp; roles</h4>
+          <p><code>GET/POST/PATCH/DELETE /User</code> — <code>username</code>, <code>password</code>, <code>fullName</code>, <code>roleUUIDs</code> (list), <code>sessionLimit</code>, <code>sessionExpiration</code>. <code>GET /Role</code> is a read-only list. <code>GET /Registration</code> is read-only.</p>
+        </div>
+      </details>
+
+      <!-- TLS -->
+      <details class="ref" id="tls" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>TLS certificate management<span class="tag">POST /Certificate</span></summary>
+        <div class="ref-body">
+          <p><code>POST /Certificate</code> with <code>{"certificate": "&lt;PEM&gt;", "privateKey": "&lt;PEM&gt;"}</code> (field is <code>privateKey</code>, camelCase).</p>
+          <ul>
+            <li><b>Per-node, not cluster-wide.</b> One POST updates only the node you connected to. Re-certificate a whole cluster by POSTing to every node's IP (<code>GET /Node</code> → <code>lanIP</code>).</li>
+            <li><b>The upload restarts that node's API server</b> — the HTTPS connection drops mid-call. Wrap the task-tag wait in a retry loop tolerating connection-reset / SSL-EOF for several attempts; the upload usually succeeded.</li>
+            <li><b>Validate before uploading</b> — a mismatched key or expired cert can leave the API unreachable (console-only recovery). Check key↔cert match, expiry, and SAN coverage.</li>
+            <li>SAN tips: include every node FQDN <b>and</b> every node IP; IPs must be <code>IP:</code> SAN entries (a <code>DNS:10.0.0.1</code> entry never matches).</li>
+            <li>No GET on <code>/Certificate</code> and no factory reset. To inspect, open a TLS connection and read the presented cert. To return to self-signed, upload a fresh self-signed cert (with a correct SAN).</li>
+          </ul>
+        </div>
+      </details>
+
+      <!-- ISO -->
+      <details class="ref" id="iso" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>ISO images<span class="tag">/ISO</span></summary>
+        <div class="ref-body">
+          <p>ISOs use <code>/ISO</code> — <code>/VirtualDisk/upload</code> <b>rejects</b> <code>.iso</code> (“File type is invalid”).</p>
+          <h4>Upload — three steps, each task-tag-waited</h4>
+          <div class="codeblock"><pre data-lang="http"><code>1. POST /ISO             {"name": "file.iso", "size": &lt;bytes&gt;, "readyForInsert": false}
+   → {"taskTag": ..., "createdUUID": "&lt;uuid&gt;"}
+2. PUT  /ISO/{uuid}/data  Content-Type: application/octet-stream, Content-Length: &lt;bytes&gt;, raw body
+3. PATCH /ISO/{uuid}      {"readyForInsert": true}</code></pre></div>
+          <p><code>name</code> must end in <code>.iso</code>; <code>size</code> is create-only; the read-only <code>path</code> field is what you mount.</p>
+          <h4>Mount / insert / eject</h4>
+          <div class="codeblock"><pre data-lang="json"><code>POST /VirDomainBlockDevice
+{"virDomainUUID": "&lt;vm-uuid&gt;", "type": "IDE_CDROM", "capacity": 0, "cacheMode": "NONE", "path": "&lt;iso.path&gt;"}</code></pre></div>
+          <p>To swap media on a <b>running</b> VM, PATCH the CDROM with <b>both</b> <code>path</code> and <code>name</code>: <code>{"path": "&lt;iso.path&gt;", "name": "&lt;iso-name&gt;"}</code> to insert, <code>{"path": "", "name": ""}</code> to eject. Sending only <code>path</code> fails the task. No ISO download endpoint (<code>GET /ISO/{uuid}/data</code> → 405).</p>
+        </div>
+      </details>
+
+      <!-- Virtual disks -->
+      <details class="ref" id="vdisk" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>Virtual disks (non-ISO images)<span class="tag">/VirtualDisk/upload</span></summary>
+        <div class="ref-body">
+          <p><code>.vmdk</code>, <code>.qcow2</code>, <code>.vhd</code>/<code>.vhdx</code>, <code>.img</code> use the VirtualDisk endpoint.</p>
+          <div class="codeblock"><pre data-lang="http"><code>PUT /rest/v1/VirtualDisk/upload?filename=name.ext&amp;filesize=N
+Content-Type: application/octet-stream
+Content-Length: N
+&lt;raw bytes&gt;</code></pre></div>
+          <ul>
+            <li>The <code>filename</code> extension determines the format and is required.</li>
+            <li><code>Content-Length</code> is <b>required</b> — chunked transfer encoding is rejected. Streaming from a URL? Get the size from a HEAD request first.</li>
+            <li>Returns <code>{"taskTag": …, "createdUUID": …}</code> — wait for the task.</li>
+          </ul>
+          <div class="note warn"><span class="lbl">Conversion tracking</span> SC//HyperCore software renames the disk during processing: <code>uploading-&lt;name&gt;</code> → <code>converting-&lt;name&gt;</code> → <code>&lt;name&gt;</code>. The record has <b>no <code>state</code> field</b> — poll <code>name</code> until it equals the final name. (ISOs have no converting phase; the v2 API returns a taskTag covering conversion.)</div>
+          <div class="codeblock"><pre data-lang="bash"><code># Stream a disk image from a URL to the cluster without a temp file
+URL="https://example.com/disk.img"
+FILESIZE=$(curl -sI "$URL" | awk 'tolower($1) ~ /content-length/ {print $2}' | tr -d '\r')
+curl -L "$URL" | curl -u &lt;user&gt;:&lt;pass&gt; -k \
+  -H "Content-Type: application/octet-stream" \
+  -H "Content-Length: $FILESIZE" \
+  -T - "https://&lt;node-ip&gt;/rest/v1/VirtualDisk/upload?filename=disk.img&amp;filesize=$FILESIZE"</code></pre></div>
+        </div>
+      </details>
+
+      <!-- Conditions -->
+      <details class="ref" id="conditions" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>Conditions (health alerts)<span class="tag">GET /Condition</span></summary>
+        <div class="ref-body">
+          <p><code>GET /Condition</code> — the <code>value</code> field is a JSON boolean. Useful pattern on API errors during heavy operations (imports, clones): fetch <code>/Condition</code> and surface any SET CRITICAL/ERROR conditions alongside the HTTP error — “SSD tier full” explains a 400 far better than “Bad Request”.</p>
+        </div>
+      </details>
+
+      <!-- Cloud image -->
+      <details class="ref" id="cloud" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>Cloud-image VM gotchas<span class="tag">Ubuntu cloud images</span></summary>
+        <div class="ref-body">
+          <p>VMs from cloud images (clone + cloud-init <code>cloudInitData</code>) have two independent failure modes that both surface when a <b>second disk is attached and the VM reboots</b>:</p>
+          <ol>
+            <li><b>Empty <code>bootDevices</code></b> → BIOS reports “No bootable device”. Always set <code>bootDevices</code> explicitly (PATCH the VM with the OS disk's UUID) after cloning/creating.</li>
+            <li><b>Grub uses <code>root=/dev/vda1</code></b> because Ubuntu cloud images set <code>GRUB_DISABLE_LINUX_UUID=true</code> — after a second disk shifts device ordering, the initramfs hangs. Fix inside the guest (re-enable UUID-based root) or keep disk ordering stable.</li>
+          </ol>
+          <div class="note right"><span class="lbl">Baseline</span> Install <code>qemu-guest-agent</code> — without it, <code>GET /VirDomain/{uuid}</code> shows <code>guestAgentState: UNAVAILABLE</code> and <code>ipv4Addresses: []</code>, so you can't find the VM's IP via the API.</div>
+          <div class="codeblock"><pre data-lang="json"><code>"cloudInitData": {"userData": "&lt;base64&gt;", "metaData": "&lt;base64&gt;"}</code></pre></div>
+        </div>
+      </details>
+
+      <!-- CBT -->
+      <details class="ref" id="cbt" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>Changed Block Tracking (snapDiff)<span class="tag">v1 · 9.6 &amp; 9.7</span></summary>
+        <div class="ref-body">
+          <p><code>POST /rest/v1/VirDomainBlockDevice/{disk-uuid}/snapDiff</code> with <code>{"snapshotSerialFrom": N, "snapshotSerialTo": M}</code> returns an array of changed block intervals (<code>[{"lower": …, "upper": …}, …]</code>) between two snapshot serials — the native CBT API used by backup integrations.</p>
+          <p>Available in the v1 API on <b>both 9.6 and 9.7</b> (present in both versions' v1 specs and the v2 spec).</p>
+          <ul>
+            <li>Serials come from <code>VirDomainSnapshot.deviceSnapshots[].serialNumber</code> (different from snapshot UUIDs).</li>
+            <li><code>snapshotSerialFrom: 0</code> means HEAD (live device state).</li>
+            <li>Although a POST, the operation is <b>read-only</b> — no taskTag, no task wait needed.</li>
+          </ul>
+        </div>
+      </details>
+
+      <!-- Fleet -->
+      <details class="ref" id="fleet" open>
+        <summary><svg class="caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="m9 6 6 6-6 6"/></svg>SC//Fleet Manager&trade; API<span class="tag">api.scalecomputing.com</span></summary>
+        <div class="ref-body">
+          <p>SC//Fleet Manager&trade; has its own API, separate from that of SC//HyperCore software: <code>https://api.scalecomputing.com/api/v2</code> with an <code>api-key</code> header (generate keys at <a href="https://fleet.scalecomputing.com" target="_blank" rel="noopener">fleet.scalecomputing.com</a>). Standard public TLS — no self-signed concerns. Collection endpoints are paginated (<code>offset</code>/<code>limit</code>, max 200 per page) — iterate if you have more clusters than one page.</p>
+        </div>
+      </details>
+    </section>
+  </main>
+</div>
+
+<footer>
+  <div class="reading">
+    <p><b>Source of truth:</b> these notes are a human-facing view of the repository docs — <code>CLAUDE.md</code>, <code>docs/hypercore-api-field-notes.md</code>, and <code>llms.txt</code>. Behavior verified on SC//HyperCore 9.6.x / 9.7.x; when the spec and these notes disagree, the notes reflect what the server enforces.</p>
+    <p><b>Better answers than raw API code, often:</b> the <a href="https://github.com/ScaleComputing/HyperCoreAnsibleCollection" target="_blank" rel="noopener">SC//HyperCore Ansible&reg; Collection</a> and the <a href="https://github.com/ScaleComputing/terraform-provider-hypercore" target="_blank" rel="noopener">Terraform&reg; provider</a> (also a reference Go client with correct task-tag handling) implement all six rules correctly.</p>
+    <p style="color:var(--text-faint);font-size:12.5px;margin-top:20px">© 2026 Scale Computing, Inc. All rights reserved. Scale Computing, SC//HyperCore, and SC//Fleet Manager are trademarks of Scale Computing, Inc. Other marks are the property of their respective owners.</p>
+  </div>
+</footer>
+
+<script>
+(function () {
+  "use strict";
+
+  /* ---- Theme toggle ---- */
+  var root = document.documentElement;
+  var themeBtn = document.getElementById("themeBtn");
+  themeBtn.addEventListener("click", function () {
+    var current = root.getAttribute("data-theme");
+    if (!current) {
+      current = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    root.setAttribute("data-theme", current === "dark" ? "light" : "dark");
+  });
+
+  /* ---- Copy buttons on code blocks ---- */
+  document.querySelectorAll(".codeblock").forEach(function (block) {
+    var pre = block.querySelector("pre");
+    if (!pre) return;
+    var lang = pre.getAttribute("data-lang");
+    if (lang) {
+      var label = document.createElement("span");
+      label.className = "lang-label";
+      label.textContent = lang;
+      block.appendChild(label);
+    }
+    var btn = document.createElement("button");
+    btn.className = "copy-btn";
+    btn.setAttribute("aria-label", "Copy code");
+    btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>';
+    btn.addEventListener("click", function () {
+      var text = pre.innerText;
+      navigator.clipboard.writeText(text).then(function () {
+        btn.classList.add("copied");
+        btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M20 6 9 17l-5-5"/></svg>';
+        setTimeout(function () {
+          btn.classList.remove("copied");
+          btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>';
+        }, 1400);
+      });
+    });
+    block.appendChild(btn);
+  });
+
+  /* ---- Scroll-spy TOC ---- */
+  var tocLinks = Array.prototype.slice.call(document.querySelectorAll("nav.toc a"));
+  var idToLink = {};
+  tocLinks.forEach(function (a) { idToLink[a.getAttribute("href").slice(1)] = a; });
+  var targets = tocLinks.map(function (a) { return document.getElementById(a.getAttribute("href").slice(1)); }).filter(Boolean);
+
+  var spy = new IntersectionObserver(function (entries) {
+    entries.forEach(function (e) {
+      if (e.isIntersecting) {
+        tocLinks.forEach(function (a) { a.classList.remove("active"); });
+        var link = idToLink[e.target.id];
+        if (link) link.classList.add("active");
+      }
+    });
+  }, { rootMargin: "-72px 0px -70% 0px", threshold: 0 });
+  targets.forEach(function (t) { spy.observe(t); });
+
+  /* ---- Expand / collapse all ---- */
+  var allDetails = Array.prototype.slice.call(document.querySelectorAll("details.ref"));
+  document.getElementById("expandAll").addEventListener("click", function () {
+    allDetails.forEach(function (d) { d.open = true; });
+  });
+  document.getElementById("collapseAll").addEventListener("click", function () {
+    allDetails.forEach(function (d) { d.open = false; });
+  });
+
+  /* ---- Filter ---- */
+  var filter = document.getElementById("filter");
+  var noResults = document.getElementById("noResults");
+  function applyFilter() {
+    var q = filter.value.trim().toLowerCase();
+    var anyVisible = false;
+    allDetails.forEach(function (d) {
+      if (!q) {
+        d.style.display = "";
+        anyVisible = true;
+        return;
+      }
+      var match = d.textContent.toLowerCase().indexOf(q) !== -1;
+      d.style.display = match ? "" : "none";
+      if (match) { d.open = true; anyVisible = true; }
+    });
+    noResults.style.display = (q && !anyVisible) ? "block" : "none";
+  }
+  filter.addEventListener("input", applyFilter);
+  filter.addEventListener("keydown", function (e) { if (e.key === "Escape") { filter.value = ""; applyFilter(); filter.blur(); } });
+
+  /* "/" focuses the filter */
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "/" && document.activeElement !== filter && !/^(input|textarea)$/i.test(document.activeElement.tagName)) {
+      e.preventDefault();
+      filter.focus();
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,27 @@
+# SC//HyperCore™ REST API Examples
+
+> Example scripts and field-tested integration notes for the SC//HyperCore™
+> REST API (https://<node-ip>/rest/v1/) and the SC//Fleet Manager™ API
+> (https://api.scalecomputing.com/api/v2).
+
+Critical conventions for generated code: every POST/PATCH/DELETE returns a
+taskTag that must be polled at GET /rest/v1/TaskTag/<tag> until terminal
+before the next call; every GET returns a single-element JSON array, even
+GET-by-UUID; many endpoints reject query filters (fetch all, filter
+client-side); clusters use self-signed TLS.
+
+## Docs
+
+- [AI assistant guide](CLAUDE.md): rules and naming traps that prevent most SC//HyperCore API bugs
+- [API field notes](docs/hypercore-api-field-notes.md): per-endpoint corrections, verified request/response shapes, and gotchas
+- [Reference VM lifecycle example](vm_lifecycle.py): create/start/migrate/clone/snapshot/delete with correct task-tag waits
+
+## Related
+
+- [SC//HyperCore Ansible® Collection](https://github.com/ScaleComputing/HyperCoreAnsibleCollection)
+- [SC//HyperCore Terraform® Provider](https://github.com/ScaleComputing/terraform-provider-hypercore)
+
+---
+
+*Scale Computing, SC//HyperCore, and SC//Fleet Manager are trademarks of
+Scale Computing, Inc. Other marks are the property of their respective owners.*


### PR DESCRIPTION
## What this adds

Documentation for both humans and AI coding assistants writing code against the SC//HyperCore™ REST API:

- **`CLAUDE.md`** — read automatically by Claude Code and other AI coding tools; distills the six rules that prevent most HyperCore API bugs (task-tag waits, single-element array responses, fetch-then-filter, self-signed TLS, update-in-progress checks, no cluster VIP) plus a naming-trap table.
- **`AGENTS.md`** — pointer file so non-Claude agents pick up the same guidance.
- **`docs/hypercore-api-field-notes.md`** — empirically verified per-endpoint field notes collected from real integration work against HyperCore 9.6.x/9.7.x clusters: request/response shape corrections, version-gated features, labels schema, snapshot/clone gotchas, ISO and virtual-disk upload flows, CBT/snapDiff.
- **`docs/hypercore-api-reference.html`** — self-contained rendered reference page (searchable, light/dark theme) of the same material.
- **`llms.txt`** — machine-readable summary for LLM crawlers.

## Review done

- Technical content cross-checked for internal consistency; references (`vm_lifecycle.py`, `Fleet Manager/`) verified against this repo.
- Trademark/branding audited (SC//HyperCore™, SC//Fleet Manager™, third-party ® marks, attribution footers).
- No credentials, internal hostnames, or private IPs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)